### PR TITLE
Use Java 21 while Docker image is still Ubuntu 20 (focal), and require .zarr conversion specification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update -y && \
     update-alternatives --config gcc && \
     apt-get install git wget libz-dev libbz2-dev liblzma-dev -y && \
     apt-get install cuda-compat-11-4 -y && \
-    apt-get install openjdk-19-jre-headless -y && \
     apt-get install r-base -y && \
     R -e "install.packages(c('argparse', 'data.table', 'ggplot2', 'reshape2', 'stringi'), dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     apt-get install vim -y
@@ -26,6 +25,12 @@ RUN mkdir /looptrace
 WORKDIR /looptrace
 COPY . /looptrace
 RUN mv /looptrace/target/scala-3.3.1/looptrace-assembly-0.2.0-SNAPSHOT.jar /looptrace/looptrace
+
+# Install minimal Java 21 runtime, in proposed repo for Ubuntu 20 (focal) as of 2023-12-14.
+RUN /bin/bash /looptrace/setup_image/allow-proposed-repos.sh && \
+    /bin/bash /looptrace/setup_image/make-proposed-repos-selective.sh && \
+    apt-get update -y && \
+    apt-get install openjdk-21-jre-headless/focal-proposed -y
 
 # Install miniconda.
 ## The installation home should be /opt/conda; if not, we need -p /path/to/install/home

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -y && \
     apt-get install git wget libz-dev libbz2-dev liblzma-dev -y && \
     apt-get install cuda-compat-11-4 -y && \
     apt-get install r-base -y && \
-    R -e "install.packages(c('argparse', 'data.table', 'ggplot2', 'reshape2', 'stringi'), dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
+    R -e "install.packages(c('argparse', 'data.table', 'ggplot2', 'stringi'), dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     apt-get install vim -y
 
 # Copy repo code, to be built later.

--- a/bin/cli/config_file_validation.py
+++ b/bin/cli/config_file_validation.py
@@ -8,7 +8,7 @@ import yaml
 from gertils import ExtantFile
 
 from looptrace.Deconvolver import REQ_GPU_KEY
-from looptrace import Drifter, MINIMUM_SPOT_SEPARATION_KEY
+from looptrace import Drifter, MINIMUM_SPOT_SEPARATION_KEY, ZARR_CONVERSIONS_KEY
 from looptrace.SpotPicker import DetectionMethod, CROSSTALK_SUBTRACTION_KEY, DETECTION_METHOD_KEY as SPOT_DETECTION_METHOD_KEY
 from looptrace.Tracer import MASK_FITS_ERROR_MESSAGE
 
@@ -43,6 +43,11 @@ def find_config_file_errors(config_file: ExtantFile) -> List[ConfigFileError]:
     
     errors = []
     
+    if not conf_data.get(ZARR_CONVERSIONS_KEY):
+        errors.append(ConfigFileError(
+            f"Conversion of image folders should be specified as mapping from src to dst folder, with key {ZARR_CONVERSIONS_KEY}."
+            ))
+
     if not conf_data.get(REQ_GPU_KEY, False):
         errors.append(ConfigFileError(f"Requiring GPUs for deconvolution with key {REQ_GPU_KEY} is currently required."))
     

--- a/bin/cli/drift_correct_accuracy_analysis.R
+++ b/bin/cli/drift_correct_accuracy_analysis.R
@@ -2,7 +2,6 @@
 library("argparse")
 library("data.table")
 library("ggplot2")
-library("reshape2")
 
 # Define some key constants.
 ## Measurement names and other column names

--- a/looptrace/ImageHandler.py
+++ b/looptrace/ImageHandler.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 import yaml
 
-from looptrace import MINIMUM_SPOT_SEPARATION_KEY
+from looptrace import MINIMUM_SPOT_SEPARATION_KEY, ZARR_CONVERSIONS_KEY
 from looptrace.filepaths import SPOT_IMAGES_SUBFOLDER, get_analysis_path, simplify_path
 from looptrace.image_io import ignore_path, NPZ_wrapper, TIFF_EXTENSIONS
 from gertils import ExtantFile, ExtantFolder
@@ -211,7 +211,7 @@ class ImageHandler:
 
     @property
     def zarr_conversions(self) -> Mapping[str, str]:
-        return self.config["zarr_conversions"]
+        return self.config.get(ZARR_CONVERSIONS_KEY, dict())
 
     def load_tables(self):
         parsers = {".csv": lambda f: pd.read_csv(f, index_col=0), ".pkl": pd.read_pickle}

--- a/looptrace/__init__.py
+++ b/looptrace/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "SIGMA_XY_MAX_NAME",
     "SIGMA_Z_MAX_NAME",
     "SIGNAL_NOISE_RATIO_NAME",
+    "ZARR_CONVERSIONS_KEY",
     ]
 
 
@@ -24,3 +25,4 @@ MINIMUM_SPOT_SEPARATION_KEY = "min_spot_dist"
 SIGMA_XY_MAX_NAME = "sigma_xy_max"
 SIGMA_Z_MAX_NAME = "sigma_z_max"
 SIGNAL_NOISE_RATIO_NAME = "A_to_BG"
+ZARR_CONVERSIONS_KEY = "zarr_conversions"

--- a/setup_image/allow-proposed-repos.sh
+++ b/setup_image/allow-proposed-repos.sh
@@ -1,0 +1,4 @@
+cat <<EOF >/etc/apt/sources.list.d/ubuntu-$(lsb_release -cs)-proposed.list
+# Enable Ubuntu proposed archive
+deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs)-proposed restricted main multiverse universe
+EOF

--- a/setup_image/make-proposed-repos-selective.sh
+++ b/setup_image/make-proposed-repos-selective.sh
@@ -1,0 +1,6 @@
+cat <<EOF >/etc/apt/preferences.d/proposed-updates
+# Configure apt to allow selective installs of packages from proposed
+Package: *
+Pin: release a=$(lsb_release -cs)-proposed
+Pin-Priority: 400
+EOF

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@
 let baseBuildInputs = with pkgs; [ poetry stdenv.cc.cc.lib zlib ] ++ [ pkgs.${jdk} ];
     py310 = pkgs.python310.withPackages (ps: with ps; [ numpy pandas ]);
     myR = pkgs.rWrapper.override{ 
-      packages = with pkgs.rPackages; [ argparse data_table ggplot2 reshape2 stringi ] ++ 
+      packages = with pkgs.rPackages; [ argparse data_table ggplot2 stringi ] ++ 
         (if rDev then [ pkgs.rPackages.languageserver ] else [ ]);
     };
     poetryExtras = [] ++ 

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@
   pyDev ? true, 
   scalaDev ? true, 
   absolutelyOnlyR ? false,
-  jdk ? "jdk19_headless",
+  jdk ? "jdk21_headless",
 }:
 let baseBuildInputs = with pkgs; [ poetry stdenv.cc.cc.lib zlib ] ++ [ pkgs.${jdk} ];
     py310 = pkgs.python310.withPackages (ps: with ps; [ numpy pandas ]);

--- a/src/main/scala/CombineImagingFolders.scala
+++ b/src/main/scala/CombineImagingFolders.scala
@@ -96,7 +96,7 @@ object CombineImagingFolders:
                 // TODO: handle case in which output folder doesn't yet exist.
                 checkSrcDstPairs(pairs)
                 println(s"Writing script: $script")
-                os.write(script, ("#!/bin/bash" :: pairs.map((src, dst) => s"mv '$src' '$dst'")).map(_ ++ "\n"))
+                os.write(script, pairs.map((src, dst) => s"mv '$src' '$dst'\n"))
                 if (execute) {
                     println(s"Executing ${pairs.length} moves")
                     pairs.foreach(os.move(_, _))


### PR DESCRIPTION
This allows us to get around error with `os-lib` and `?` home folder related to running on Java 17 (at least when having assembled JAR with Java 19) while still being based on Ubuntu 20 (focal), while adopting a LTS Java version.

Close #156
Close #159 