### PR TITLE
Drift correction robustness, docs update, 

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,5 @@
+linters: with_defaults(
+  indentation_linter: intentation_linter(
+    intent = 4L      
+  )
+)

--- a/bin/cli/generate_excution_control_document.py
+++ b/bin/cli/generate_excution_control_document.py
@@ -1,6 +1,7 @@
 """Script to generate the pipeline execution control documentation"""
 
 import argparse
+import os
 import sys
 from typing import *
 
@@ -24,7 +25,7 @@ def _parse_cmdl(cmdl: List[str]) -> argparse.Namespace:
     return parser.parse_args(cmdl)
 
 
-DOCTEXT = f"""
+DOCTEXT = f"""<!--- DO NOT EDIT THIS GENERATED DOCUMENT DIRECTLY; instead, edit {os.path.basename(__file__)} --->
 # Controlling pipeline execution
 ## Overview
 The main `looptrace` processing pipeline is built with [pypiper](https://pypi.org/project/piper/).

--- a/bin/cli/generate_excution_control_document.py
+++ b/bin/cli/generate_excution_control_document.py
@@ -6,7 +6,7 @@ from typing import *
 
 __author__ = "Vince Reuter"
 
-from run_processing_pipeline import DECON_STAGE_NAME, SPOT_DETECTION_STAGE_NAME, TRACING_QC_STAGE_NAME, LooptracePipeline
+from run_processing_pipeline import DECON_STAGE_NAME, PIPE_NAME, SPOT_DETECTION_STAGE_NAME, TRACING_QC_STAGE_NAME, LooptracePipeline
 
 
 def _parse_cmdl(cmdl: List[str]) -> argparse.Namespace:
@@ -24,18 +24,21 @@ def _parse_cmdl(cmdl: List[str]) -> argparse.Namespace:
     return parser.parse_args(cmdl)
 
 
-DOCTEXT = """
+DOCTEXT = f"""
 # Controlling pipeline execution
 ## Overview
 The main `looptrace` processing pipeline is built with [pypiper](https://pypi.org/project/piper/).
 One feature of such a pipeline is that it may be started and stopped at arbitrary points.
 To do so, the start and end points must be specified by name of processing stage.
 
-To __start__ the pipeline from a specific point, use `--start-point <stage name>`.
+To __start__ the pipeline from a specific point, use `--start-point <stage name>`. Example:
+```python
+python run_processing_pipeline.py -C conf.yaml -I images_folder -O pypiper_output --start-point {SPOT_DETECTION_STAGE_NAME} --stop-before {TRACING_QC_STAGE_NAME}
+```
 
-To __stop__ the pipeline...
-    * ...just _before_ a specific point, use `--stop-before <stage name>`.
-    * ...just _after_ a specific point, use `--stop-after <stage name>`.
+To __stop__ the pipeline...<br>
+* ...just _before_ a specific point, use `--stop-before <stage name>`.
+* ...just _after_ a specific point, use `--stop-after <stage name>`.
 
 ## Restarting the pipeline...
 When experimenting with different parameter settings for one or more stages, it's common to want to restart the pipeline from a specific point.
@@ -50,7 +53,7 @@ You should copy to this folder any checkpoint files of any stages upstream of th
 Even though `--start-point` should allow the restart to begin from where's desired, if that's forgotten the checkpoint files should save you.
 
 Generate an empty checkpoint file for each you'd like to skip. 
-Simply create (`touch`) each such file `<stage>.checkpoint` in the desired pypiper output folder.
+Simply create (`touch`) each such file `{PIPE_NAME}_<stage>.checkpoint` in the desired pypiper output folder.
 Below are the sequential pipeline stage names.
 
 ### Pipeline stage names

--- a/bin/cli/run_processing_pipeline.py
+++ b/bin/cli/run_processing_pipeline.py
@@ -77,9 +77,11 @@ def plot_spot_counts(config_file: ExtantFile, spot_type: "SpotType") -> None:
     if spot_type == SpotType.REGIONAL:
         unfiltered = H.raw_spots_file
         filtered = H.proximity_filtered_spots_file_path
+        probe_name_extra = ["--probe-names", " ".join(H.frame_names)]
     elif spot_type == SpotType.LOCUS_SPECIFIC:
         unfiltered = H.traces_file_qc_unfiltered
         filtered = H.traces_file_qc_filtered
+        probe_name_extra = []
     else:
         raise ValueError(f"Illegal spot_type for plotting spot counts: {spot_type}")
     analysis_cmd_parts = [
@@ -93,7 +95,7 @@ def plot_spot_counts(config_file: ExtantFile, spot_type: "SpotType") -> None:
         spot_type.value,
         "-o", 
         output_folder, 
-        ]
+        ] + probe_name_extra
     print(f"Analysis command: {' '.join(analysis_cmd_parts)}")
     return subprocess.check_call(analysis_cmd_parts)
 

--- a/bin/cli/spot_counts_visualisation.R
+++ b/bin/cli/spot_counts_visualisation.R
@@ -9,27 +9,24 @@ kPlotColor <- c("lightcoral", "indianred4")
 kRegionalName <- "regional"
 kSpotCountPrefix <- "spot_counts"
 
-# Save a bead ROIs counts plot in the current output folder (by CLI), with a particular prefix for the name to indicate content and type.
+# Augment the (regional) spots table with probe names, since--unlike for the 
+# locus-specific spots table--that information's not added to the regional spots table.
 #
 # Args:
-#   fig: the plot to save to disk
-#   filtered_or_not: either 'filtered' or 'unfiltered', indicating whether the spots had been filtered
-#   spot_type_name: either 'regional' or 'locus_specific', indicating the type of spots data used
-saveCountsPlot <- function(fig, spot_type_name, plot_type_name, output_folder) {
-    fn <- sprintf("%s.%s.%s.png", kSpotCountPrefix, spot_type_name, plot_type_name)
-    plotfile <- file.path(output_folder, fn)
-    message("Saving plot: ", plotfile)
-    ggsave(filename = plotfile, plot = fig)
-    plotfile
+#   spots_table: data table with regional spots data
+#   probe_names: ordered list of names to give the imaging timepoints
+addProbeNames <- function(spots_table, probe_names) {
+    if ("frame_name" %in% colnames(spots_table)) { stop("Table alread contains column for probe names!") }
+    spots_table$frame_name <- sapply(spots_table$frame, function(i) probe_names[i + 1])
+    spots_table
 }
 
 # Create the heatmap for the given counts data (1 count per (FOV, time) pair).
 buildCountsHeatmap <- function(spots_table) {
-    counts_table <- spots_table[, .(count = .N), by = list(position, frame)]
-    counts_table$frame <- as.factor(counts_table$frame)
-    ggplot(counts_table, aes(x = frame, y = position, fill = count)) + 
+    counts_table <- spots_table[, .(count = .N), by = list(position, frame_name)]
+    ggplot(counts_table, aes(x = frame_name, y = position, fill = count)) + 
         geom_tile() + 
-        xlab("timepoint") + 
+        xlab("probe") + 
         theme_bw()
 }
 
@@ -45,12 +42,27 @@ plotAndWriteToFile <- function(spots_table, filtered_or_not, spot_type_name, out
     }
     p <- buildCountsHeatmap(spots_table)
     p <- p + ggtitle(sprintf("Counts of %s spots, %s", kRegionalName, filtered_or_not))
+    p <- p + theme(axis.text.x = element_text(angle = 90, vjust = 0.5))
     saveCountsPlot(
         fig = p, 
         spot_type_name = spot_type_name, 
         plot_type_name = sprintf("%s.heatmap", filtered_or_not), 
         output_folder = output_folder
         )
+}
+
+# Save a bead ROIs counts plot in the current output folder (by CLI), with a particular prefix for the name to indicate content and type.
+#
+# Args:
+#   fig: the plot to save to disk
+#   filtered_or_not: either 'filtered' or 'unfiltered', indicating whether the spots had been filtered
+#   spot_type_name: either 'regional' or 'locus_specific', indicating the type of spots data used
+saveCountsPlot <- function(fig, spot_type_name, plot_type_name, output_folder) {
+    fn <- sprintf("%s.%s.%s.png", kSpotCountPrefix, spot_type_name, plot_type_name)
+    plotfile <- file.path(output_folder, fn)
+    message("Saving plot: ", plotfile)
+    ggsave(filename = plotfile, plot = fig)
+    plotfile
 }
 
 ############################################################################################
@@ -60,23 +72,47 @@ plotAndWriteToFile <- function(spots_table, filtered_or_not, spot_type_name, out
 ## Parser
 cli_parser <- ArgumentParser(description="Visualise bead ROI detection results")
 ## Required
-cli_parser$add_argument("--filtered-spots-file", required = TRUE, help = "Path to filtered detected spots file")
-cli_parser$add_argument("--unfiltered-spots-file", help = "Path to unfiltered detected spots file; required for regional spots")
-cli_parser$add_argument("-o", "--output-folder", required = TRUE, help = "Path to folder in which to place output files")
-cli_parser$add_argument("--spot-file-type", choices = c(kRegionalName, kLocusSpecificName), help = "Which kind of spots files are being provided")
+cli_parser$add_argument(
+    "--filtered-spots-file", 
+    required = TRUE, 
+    help = "Path to filtered detected spots file"
+    )
+cli_parser$add_argument(
+    "--probe-names", 
+    nargs = "*",
+    help = "Ordered list of names, used to each frame/timepoint with a probe; required iff spots data is regional"
+    )
+cli_parser$add_argument(
+    "-o", "--output-folder", 
+    required = TRUE, 
+    help = "Path to folder in which to place output files"
+    )
+cli_parser$add_argument(
+    "--unfiltered-spots-file", 
+    help = "Path to unfiltered detected spots file; required iff spots data is regional"
+    )
+cli_parser$add_argument(
+    "--spot-file-type", 
+    choices = c(kRegionalName, kLocusSpecificName), 
+    help = "Which kind of spots files are being provided"
+    )
 ## Parse the CLI arguments.s
 opts <- cli_parser$parse_args()
 
 # Handle the different execution branches (spots either from regional barcode or locus-specific probes).
 if (opts$spot_file_type == kRegionalName) {
-    if (is.null(opts$unfiltered_spots_file)) {
-        stop(sprintf("For plotting %s spot counts, a path to an unfiltered file is additionally required.", kRegionalName))
+    if (is.null(opts$unfiltered_spots_file) || is.null(opts$probe_names)) {
+        stop(sprintf(
+            "For plotting %s spot counts, a list of probe names and a path to an unfiltered file are additionally required.", 
+            kRegionalName
+            ))
     }
+    addProbes <- function(spots_table) { addProbeNames(spots_table, opts$probe_names) }
     # First, read the data tables.
     message("Reading unfiltered spots table: ", opts$unfiltered_spots_file)
-    unfilteredSpots <- fread(opts$unfiltered_spots_file)
+    unfilteredSpots <- addProbes(fread(opts$unfiltered_spots_file))
     message("Reading filtered spots table: ", opts$filtered_spots_file)
-    filteredSpots <- fread(opts$filtered_spots_file)
+    filteredSpots <- addProbes(fread(opts$filtered_spots_file))
     # Then, build the charts and save them to disk.
     plotAndWrite <- function(spots_table, filtered_or_not) { 
         plotAndWriteToFile(
@@ -92,10 +128,10 @@ if (opts$spot_file_type == kRegionalName) {
     # Create a side-by-side grouped barchart, with unfiltered count next to filtered count for each timepoint.
     unfilteredSpots$filter_status <- FALSE
     filteredSpots$filter_status <- TRUE
-    spotCountsCombined <- rbindlist(list(unfilteredSpots, filteredSpots))[, .(count = .N), by = list(filter_status, frame)]
-    combinedBarchart <- ggplot(spotCountsCombined, aes(x = as.factor(frame), y = count, fill = filter_status)) + 
+    spotCountsCombined <- rbindlist(list(unfilteredSpots, filteredSpots))[, .(count = .N), by = list(filter_status, frame_name)]
+    combinedBarchart <- ggplot(spotCountsCombined, aes(x = as.factor(frame_name), y = count, fill = filter_status)) + 
         geom_bar(stat = "identity", position = "dodge") + 
-        xlab("timepoint") + 
+        xlab("probe") + 
         ggtitle(sprintf("Spot counts, %s", kRegionalName)) + 
         scale_fill_manual(name = element_blank(), values = kPlotColor, labels = c("unfiltered", "filtered")) + 
         labs(fill = element_blank()) + 
@@ -116,11 +152,12 @@ if (opts$spot_file_type == kRegionalName) {
         spot_type_name = opts$spot_file_type, 
         output_folder = opts$output_folder
         )
-    bargraph <- ggplot(filteredSpots[, .(count = .N), by = frame], aes(x = as.factor(frame), y = count)) + 
+    bargraph <- ggplot(filteredSpots[, .(count = .N), by = frame_name], aes(x = frame_name, y = count)) + 
         geom_bar(stat = "identity") + 
-        xlab("timepoint") + 
+        xlab("probe") + 
         ggtitle(sprintf("Spot counts, %s", kLocusSpecificName)) + 
-        theme_bw()
+        theme_bw() + 
+        theme(axis.text.x = element_text(angle = 90, vjust = 0.5))
     saveCountsPlot(
         fig = bargraph, 
         spot_type_name = opts$spot_file_type, 

--- a/bin/cli/spot_counts_visualisation.R
+++ b/bin/cli/spot_counts_visualisation.R
@@ -4,20 +4,10 @@ library("argparse")
 library("data.table")
 library("ggplot2")
 
-# CLI definition and parsing
-## Parser
-cli_parser <- ArgumentParser(description="Visualise bead ROI detection results")
-## Required
-cli_parser$add_argument("--unfiltered-spots-file", required = TRUE, help = "Path to unfiltered detected spots file")
-cli_parser$add_argument("--filtered-spots-file", required = TRUE, help = "Path to filtered detected spots file")
-cli_parser$add_argument("-o", "--output-folder", required = TRUE, help = "Path to folder in which to place output files")
-cli_parser$add_argument("--spot-file-type", choices = c("regional", "locus_specific"), help = "Which kind of spots files are being provided")
-## Parse the CLI arguments.s
-opts <- cli_parser$parse_args()
-
-kSpotCountPrefix <- "spot_counts"
-kPlotTitlePrefix <- "Counts of detected spots"
+kLocusSpecificName <- "locus-specific"
 kPlotColor <- c("lightcoral", "indianred4")
+kRegionalName <- "regional"
+kSpotCountPrefix <- "spot_counts"
 
 # Save a bead ROIs counts plot in the current output folder (by CLI), with a particular prefix for the name to indicate content and type.
 #
@@ -25,9 +15,9 @@ kPlotColor <- c("lightcoral", "indianred4")
 #   fig: the plot to save to disk
 #   filtered_or_not: either 'filtered' or 'unfiltered', indicating whether the spots had been filtered
 #   spot_type_name: either 'regional' or 'locus_specific', indicating the type of spots data used
-saveCountsPlot <- function(fig, spot_type_name, plot_type_name) {
-    fn <- sprintf("%s.%s.%s.png", spot_type_name, kSpotCountPrefix, plot_type_name)
-    plotfile <- file.path(opts$output_folder, fn)
+saveCountsPlot <- function(fig, spot_type_name, plot_type_name, output_folder) {
+    fn <- sprintf("%s.%s.%s.png", kSpotCountPrefix, spot_type_name, plot_type_name)
+    plotfile <- file.path(output_folder, fn)
     message("Saving plot: ", plotfile)
     ggsave(filename = plotfile, plot = fig)
     plotfile
@@ -46,44 +36,99 @@ buildCountsHeatmap <- function(spots_table) {
 # Create a heatmap and save the plot to an appropriately named file in the current output folder.
 #
 # Args:
-#   spots_table: data table with (regional or locus-specific) detected spots data
+#   spots_table: data table with (regional or locus-specific) spots data
 #   filtered_or_not: either 'filtered' or 'unfiltered', indicating whether the spots have been filtered
 #   spot_type_name: either 'regional' or 'locus_specific', indicating the type of spots data passed
-plotAndWriteToFile <- function(spots_table, filtered_or_not, spot_type_name) {
+plotAndWriteToFile <- function(spots_table, filtered_or_not, spot_type_name, output_folder) {
     if ( ! (filtered_or_not %in% c("filtered", "unfiltered"))) {
         stop("Illegal value for filtered/not argument: ", filtered_or_not)
     }
     p <- buildCountsHeatmap(spots_table)
-    p <- p + ggtitle(sprintf("%s, %s", kPlotTitlePrefix, filtered_or_not))
-    saveCountsPlot(fig = p, spot_type_name = spot_type_name, plot_type_name = sprintf("%s.heatmap", filtered_or_not))
+    p <- p + ggtitle(sprintf("Counts of %s spots, %s", kRegionalName, filtered_or_not))
+    saveCountsPlot(
+        fig = p, 
+        spot_type_name = spot_type_name, 
+        plot_type_name = sprintf("%s.heatmap", filtered_or_not), 
+        output_folder = output_folder
+        )
 }
 
 ############################################################################################
 # Run program
 ############################################################################################
+# CLI definition and parsing
+## Parser
+cli_parser <- ArgumentParser(description="Visualise bead ROI detection results")
+## Required
+cli_parser$add_argument("--filtered-spots-file", required = TRUE, help = "Path to filtered detected spots file")
+cli_parser$add_argument("--unfiltered-spots-file", help = "Path to unfiltered detected spots file; required for regional spots")
+cli_parser$add_argument("-o", "--output-folder", required = TRUE, help = "Path to folder in which to place output files")
+cli_parser$add_argument("--spot-file-type", choices = c(kRegionalName, kLocusSpecificName), help = "Which kind of spots files are being provided")
+## Parse the CLI arguments.s
+opts <- cli_parser$parse_args()
 
-# First, read the data tables.
-message("Reading unfiltered spots table: ", opts$unfiltered_spots_file)
-unfilteredSpots <- fread(opts$unfiltered_spots_file)
-message("Reading filtered spots table: ", opts$filtered_spots_file)
-filteredSpots <- fread(opts$filtered_spots_file)
-
-# Then, build the charts and save them to disk.
-message("Creating and saving plots...")
-plotAndWriteToFile(spots_table = unfilteredSpots, filtered_or_not = "unfiltered", spot_type_name = opts$spot_file_type)
-plotAndWriteToFile(spots_table = filteredSpots, filtered_or_not = "filtered", spot_type_name = opts$spot_file_type)
-
-# Create a side-by-side grouped barchart, with unfiltered count next to filtered count for each timepoint.
-unfilteredSpots$filter_status <- FALSE
-filteredSpots$filter_status <- TRUE
-spotCountsCombined <- rbindlist(list(unfilteredSpots, filteredSpots))[, .(count = .N), by = list(filter_status, frame)]
-combinedBarchart <- ggplot(spotCountsCombined, aes(x = as.factor(frame), y = count, fill = filter_status)) + 
-    geom_bar(stat = "identity", position = "dodge") + 
-    xlab("timepoint") + 
-    ggtitle(kPlotTitlePrefix) + 
-    scale_fill_manual(name = element_blank(), values = kPlotColor, labels = c("unfiltered", "filtered")) + 
-    labs(fill = element_blank()) + 
-    theme_bw()
-saveCountsPlot(fig = combinedBarchart, spot_type_name = opts$spot_file_type, plot_type_name = "combined.bargraph")
+# Handle the different execution branches (spots either from regional barcode or locus-specific probes).
+if (opts$spot_file_type == kRegionalName) {
+    if (is.null(opts$unfiltered_spots_file)) {
+        stop(sprintf("For plotting %s spot counts, a path to an unfiltered file is additionally required.", kRegionalName))
+    }
+    # First, read the data tables.
+    message("Reading unfiltered spots table: ", opts$unfiltered_spots_file)
+    unfilteredSpots <- fread(opts$unfiltered_spots_file)
+    message("Reading filtered spots table: ", opts$filtered_spots_file)
+    filteredSpots <- fread(opts$filtered_spots_file)
+    # Then, build the charts and save them to disk.
+    plotAndWrite <- function(spots_table, filtered_or_not) { 
+        plotAndWriteToFile(
+            spots_table = spots_table, 
+            filtered_or_not = filtered_or_not, 
+            spot_type_name = opts$spot_file_type, 
+            output_folder = opts$output_folder
+            )
+    }
+    message(sprintf("Creating and saving %s spot counts plots...", kRegionalName))
+    plotAndWrite(spots_table = unfilteredSpots, filtered_or_not = "unfiltered")
+    plotAndWrite(spots_table = filteredSpots, filtered_or_not = "filtered")
+    # Create a side-by-side grouped barchart, with unfiltered count next to filtered count for each timepoint.
+    unfilteredSpots$filter_status <- FALSE
+    filteredSpots$filter_status <- TRUE
+    spotCountsCombined <- rbindlist(list(unfilteredSpots, filteredSpots))[, .(count = .N), by = list(filter_status, frame)]
+    combinedBarchart <- ggplot(spotCountsCombined, aes(x = as.factor(frame), y = count, fill = filter_status)) + 
+        geom_bar(stat = "identity", position = "dodge") + 
+        xlab("timepoint") + 
+        ggtitle(sprintf("Spot counts, %s", kRegionalName)) + 
+        scale_fill_manual(name = element_blank(), values = kPlotColor, labels = c("unfiltered", "filtered")) + 
+        labs(fill = element_blank()) + 
+        theme_bw()
+    saveCountsPlot(
+        fig = combinedBarchart, 
+        spot_type_name = opts$spot_file_type, 
+        plot_type_name = "bargraph", 
+        output_folder = opts$output_folder
+        )
+} else if (opts$spot_file_type == kLocusSpecificName) {
+    message("Reading filtered spots table: ", opts$filtered_spots_file)
+    filteredSpots <- fread(opts$filtered_spots_file)
+    message(sprintf("Creating and saving %s spot counts plot...", kLocusSpecificName))
+    plotAndWriteToFile(
+        spots_table = filteredSpots, 
+        filtered_or_not = "filtered", 
+        spot_type_name = opts$spot_file_type, 
+        output_folder = opts$output_folder
+        )
+    bargraph <- ggplot(filteredSpots[, .(count = .N), by = frame], aes(x = as.factor(frame), y = count)) + 
+        geom_bar(stat = "identity") + 
+        xlab("timepoint") + 
+        ggtitle(sprintf("Spot counts, %s", kLocusSpecificName)) + 
+        theme_bw()
+    saveCountsPlot(
+        fig = bargraph, 
+        spot_type_name = opts$spot_file_type, 
+        plot_type_name = "bargraph", 
+        output_folder = opts$output_folder
+        )
+} else {
+    stop("Illegal value for spot file type: ", opts$spot_file_type)
+}
 
 message("Done!")

--- a/docs/pipeline-execution-control-and-restart.md
+++ b/docs/pipeline-execution-control-and-restart.md
@@ -5,11 +5,14 @@ The main `looptrace` processing pipeline is built with [pypiper](https://pypi.or
 One feature of such a pipeline is that it may be started and stopped at arbitrary points.
 To do so, the start and end points must be specified by name of processing stage.
 
-To __start__ the pipeline from a specific point, use `--start-point <stage name>`.
+To __start__ the pipeline from a specific point, use `--start-point <stage name>`. Example:
+```python
+python run_processing_pipeline.py -C conf.yaml -I images_folder -O pypiper_output --start-point spot_detection --stop-before tracing_QC
+```
 
-To __stop__ the pipeline...
-    * ...just _before_ a specific point, use `--stop-before <stage name>`.
-    * ...just _after_ a specific point, use `--stop-after <stage name>`.
+To __stop__ the pipeline...<br>
+* ...just _before_ a specific point, use `--stop-before <stage name>`.
+* ...just _after_ a specific point, use `--stop-after <stage name>`.
 
 ## Restarting the pipeline...
 When experimenting with different parameter settings for one or more stages, it's common to want to restart the pipeline from a specific point.
@@ -24,7 +27,7 @@ You should copy to this folder any checkpoint files of any stages upstream of th
 Even though `--start-point` should allow the restart to begin from where's desired, if that's forgotten the checkpoint files should save you.
 
 Generate an empty checkpoint file for each you'd like to skip. 
-Simply create (`touch`) each such file `<stage>.checkpoint` in the desired pypiper output folder.
+Simply create (`touch`) each such file `looptrace_<stage>.checkpoint` in the desired pypiper output folder.
 Below are the sequential pipeline stage names.
 
 ### Pipeline stage names

--- a/docs/pipeline-execution-control-and-restart.md
+++ b/docs/pipeline-execution-control-and-restart.md
@@ -1,4 +1,4 @@
-
+<!--- DO NOT EDIT THIS GENERATED DOCUMENT DIRECTLY; instead, edit generate_excution_control_document.py --->
 # Controlling pipeline execution
 ## Overview
 The main `looptrace` processing pipeline is built with [pypiper](https://pypi.org/project/piper/).

--- a/docs/running_the_pipeline.md
+++ b/docs/running_the_pipeline.md
@@ -33,7 +33,7 @@ The path to the configuration file is a required parameter to [run the pipeline]
 * `decon_input_name` should likely be the single value in the `zarr_conversions` mapping.
 * `reg_input_template` and `reg_input_moving` should likely match each other and should correspond to adding a `_decon` suffix to the value of `decon_input_name`.
 * `reg_ref_frame` should be set to something approximately equal to the middle of the imaging timecourse (i.e, midway between first and last timepoint).
-* `bead_points` should be set to 100 or 200 (number of beads to use for drift correction).
+* `num_bead_rois_for_drift_correction` should be set to 100 or 200 (number of beads to use for drift correction).
 Having bead count fewer than the value will impede processing, but higher values _may_ given a bit better drift correction.
 Judge in accordance with how many beads you anticipate having per image.
 * `num_bead_rois_for_drift_correction_accuracy` should be set to 100.

--- a/looptrace/Drifter.py
+++ b/looptrace/Drifter.py
@@ -306,7 +306,7 @@ def compute_fine_drifts(drifter: "Drifter") -> None:
         Data for each row of the fine/full drift correction table
     """
     roi_px = drifter.bead_roi_px
-    beads_exp_shape = (drifter.num_bead_points, 3)
+    beads_exp_shape = (drifter.num_bead_rois_for_drift_correction, 3)
     for position, position_group in iter_coarse_drifts_by_position(filepath=drifter.dc_file_path__coarse):
         pos_idx = drifter.full_pos_list.index(position)
         if not drifter.overwrite and drifter.checkpoint_filepath(pos_idx=pos_idx).is_file():
@@ -474,7 +474,7 @@ class Drifter():
         return self.config['reg_ch_moving']
 
     @property
-    def num_bead_points(self) -> int:
+    def num_bead_rois_for_drift_correction(self) -> int:
         return self.image_handler.num_bead_rois_for_drift_correction
 
     @property

--- a/looptrace/ImageHandler.py
+++ b/looptrace/ImageHandler.py
@@ -150,7 +150,7 @@ class ImageHandler:
 
     @property
     def num_bead_rois_for_drift_correction(self) -> int:
-        return self.config["bead_points"]
+        return self.config["num_bead_rois_for_drift_correction"]
 
     @property
     def num_bead_rois_for_drift_correction_accuracy(self) -> int:

--- a/src/main/scala/BeadRois.scala
+++ b/src/main/scala/BeadRois.scala
@@ -1,5 +1,6 @@
 package at.ac.oeaw.imba.gerlich.looptrace
 
+import scala.util.NotGiven
 import upickle.default.*
 import at.ac.oeaw.imba.gerlich.looptrace.space.{ Coordinate, CoordinateSequence, Point3D }
 
@@ -36,7 +37,9 @@ object SelectedRoi:
         )
 
     /** Serialise the index as a simple integer, and centroid as a simple array of Double, sequenced as requested. */
-    def simpleJsonReadWriter[R <: SelectedRoi](coordseq: CoordinateSequence, build: (RoiIndex, Point3D) => R): ReadWriter[R] = {
+    private def simpleJsonReadWriter[R <: SelectedRoi : [R] =>> NotGiven[R =:= SelectedRoi]](
+        coordseq: CoordinateSequence, build: (RoiIndex, Point3D) => R
+        ): ReadWriter[R] = {
         readwriter[ujson.Value].bimap[R](
             toJsonSimple(coordseq), 
             json => {

--- a/src/main/scala/BeadRois.scala
+++ b/src/main/scala/BeadRois.scala
@@ -4,11 +4,15 @@ import scala.util.NotGiven
 import upickle.default.*
 import at.ac.oeaw.imba.gerlich.looptrace.space.{ Coordinate, CoordinateSequence, Point3D }
 
+sealed trait RoiLike:
+    def index: RoiIndex
+    def centroid: Point3D
+
 /** Type representing a detected fiducial bead region of interest (ROI) */
-final case class DetectedRoi(index: RoiIndex, centroid: Point3D, isUsable: Boolean)
+final case class DetectedRoi(index: RoiIndex, centroid: Point3D, isUsable: Boolean) extends RoiLike
 
 /** A region of interest (ROI) selected for use in some process */
-sealed trait SelectedRoi {
+sealed trait SelectedRoi extends RoiLike {
     def index: RoiIndex
     def centroid: Point3D
 }

--- a/src/main/scala/BeadRois.scala
+++ b/src/main/scala/BeadRois.scala
@@ -4,12 +4,24 @@ import scala.util.NotGiven
 import upickle.default.*
 import at.ac.oeaw.imba.gerlich.looptrace.space.{ Coordinate, CoordinateSequence, Point3D }
 
+/** A type wrapper around a string with which to represent the reason(s) why a bead ROI is unusable */
+final case class RoiFailCode(get: String):
+    def indicatesFailure: Boolean = get.nonEmpty
+    def indicatesSuccess: Boolean = !indicatesFailure
+end RoiFailCode
+
+/** Helpers for working with {@code RoiFailCode} values */
+object RoiFailCode:
+    def success = RoiFailCode("")
+
+/** An entity which has a {@code RoiIndex} and a centroid */
 sealed trait RoiLike:
     def index: RoiIndex
     def centroid: Point3D
 
 /** Type representing a detected fiducial bead region of interest (ROI) */
-final case class DetectedRoi(index: RoiIndex, centroid: Point3D, isUsable: Boolean) extends RoiLike
+final case class DetectedRoi(index: RoiIndex, centroid: Point3D, failCode: RoiFailCode) extends RoiLike:
+    def isUsable: Boolean = failCode.indicatesSuccess
 
 /** A region of interest (ROI) selected for use in some process */
 sealed trait SelectedRoi extends RoiLike {

--- a/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
+++ b/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
@@ -474,7 +474,10 @@ object PartitionIndexedDriftCorrectionRois:
                 }
             }
 
-            case class RepeatedRoisWithinPartError private[Partition](shifting: Map[RoiForShifting, Int], accuracy: Map[RoiForAccuracy, Int]) extends Throwable
+            case class RepeatedRoisWithinPartError private[Partition](shifting: Map[RoiForShifting, Int], accuracy: Map[RoiForAccuracy, Int]) extends Throwable:
+                require(shifting.nonEmpty || accuracy.nonEmpty, s"Cannot build a ROI repeats exception with 2 empty maps!")
+                require(shifting.forall(_._2 > 1), s"Cannot allege that a 'repeat' occurs fewer than two times: ${shifting.filter(_._2 < 2)}")
+                require(accuracy.forall(_._2 > 1), s"Cannot allege that a 'repeat' occurs fewer than two times: ${accuracy.filter(_._2 < 2)}")
         end Partition
     end RoisSplit
     

--- a/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
+++ b/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
@@ -3,14 +3,7 @@ package at.ac.oeaw.imba.gerlich.looptrace
 import scala.util.{ Random, Try }
 import cats.Alternative
 import cats.data.{ NonEmptyList as NEL, ValidatedNel }
-import cats.syntax.apply.*
-import cats.syntax.either.*
-import cats.syntax.eq.*
-import cats.syntax.flatMap.*
-import cats.syntax.functor.*
-import cats.syntax.list.*
-import cats.syntax.option.*
-import cats.syntax.validated.*
+import cats.syntax.all.*
 import mouse.boolean.*
 import upickle.default.*
 import scopt.OParser

--- a/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
+++ b/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
@@ -104,7 +104,6 @@ object PartitionIndexedDriftCorrectionRois:
         referenceFrame: Option[FrameIndex],
         outputFolder: Option[os.Path]
         ): Unit = {
-        import TooFewRoisLike.*
 
         val parserConfig = conf match {
             case pc: ParserConfig => pc
@@ -195,7 +194,6 @@ object PartitionIndexedDriftCorrectionRois:
     )
 
     def writeTooFewRois[E : TooFewRoisLike] = (pf: PosFramePair, error: E) => {
-        import TooFewRoisLike.*
         val tooFew = error.problem
         ujson.Obj(
             "position" -> ujson.Num(pf._1.get),
@@ -353,12 +351,12 @@ object PartitionIndexedDriftCorrectionRois:
     final case class TooFewRois(requested: PositiveInt, realized: Int, purpose: Purpose) derives ReadWriter:
         require(requested > realized, s"Count of realized ROIs ($realized) isn't less than count of requested ($requested)")
     
+    /** A type which admits a {@code TooFewRois} value */
     trait TooFewRoisLike[A]:
         def getTooFew: A => TooFewRois
 
-    object TooFewRoisLike:
-        extension [A](a: A)(using ev: TooFewRoisLike[A])
-            def problem = ev.getTooFew(a)
+    extension [A](a: A)(using ev: TooFewRoisLike[A])
+        def problem = ev.getTooFew(a)
 
     object RoisSplitResult:
         def intoEither = (_: RoisSplitResult) match {

--- a/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
+++ b/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
@@ -116,7 +116,7 @@ object PartitionIndexedDriftCorrectionRois:
         val writeRois = (rois: List[SelectedRoi], outpath: os.Path) => {
             println(s"Writing: $outpath")
             val jsonObjs = rois.map { r => SelectedRoi.toJsonSimple(parserConfig.coordinateSequence)(r) }
-            os.makeDir.all(os.Path(outpath.toNIO.getParent))
+            os.makeDir.all(outpath.parent)
             os.write.over(outpath, ujson.write(jsonObjs, indent = 4))
         }
         

--- a/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
+++ b/src/main/scala/PartitionIndexedDriftCorrectionRois.scala
@@ -454,7 +454,7 @@ object PartitionIndexedDriftCorrectionRois:
         object Partition:
             import at.ac.oeaw.imba.gerlich.looptrace.collections.*
             def build(reqShifting: ShiftingCount, shifting: List[RoiForShifting], reqAccuracy: PositiveInt, accuracy: List[RoiForAccuracy]): Result = {
-                // Derive {@code Ordering} from an {@code Order} instance already in scope.
+                // Derive Ordering instance from an Order instance already in scope.
                 given orderForShiftingRoi: Order[RoiForShifting] = Order.by(simplifySelectedRoi)
                 given orderForAccuracyRoi: Order[RoiForAccuracy] = Order.by(simplifySelectedRoi)
                 given orderingFromOrder[A](using ord: Order[A]): Ordering[A] = ord.toOrdering

--- a/src/main/scala/TracingOutputAnalysis.scala
+++ b/src/main/scala/TracingOutputAnalysis.scala
@@ -10,7 +10,16 @@ import at.ac.oeaw.imba.gerlich.looptrace.CsvHelpers.*
 import at.ac.oeaw.imba.gerlich.looptrace.UJsonHelpers.*
 import at.ac.oeaw.imba.gerlich.looptrace.syntax.*
 
-/** Tools for analysing chromatin fiber tracing (typically *_traces*.csv) */
+/**
+ * Tools for analysing chromatin fiber tracing (typically *_traces*.csv)
+ * 
+ * Originally developed for Neos, to count the number of locus-specific spots 
+ * kept on a per-(ref_frame, frame) basis. That is, how many locus-specific 
+ * spots are available (after QC filtering) per specific target (using a 
+ * two-stage multiplex).
+ * 
+ * @author Vince Reuter
+ */
 object TracingOutputAnalysis:
     
     /** Pairing or regional and locus-specific FISH spot, a common key by which to group and/or filter records */

--- a/src/main/scala/collections.scala
+++ b/src/main/scala/collections.scala
@@ -1,9 +1,23 @@
 package at.ac.oeaw.imba.gerlich.looptrace
 
+import scala.collection.immutable.SortedSet
+import cats.*
+import cats.data.*
 import cats.syntax.all.*
 
 /** Tools for working with collections */
 package object collections:
+    /** Syntax helpers for working with various Set implementations */
+    extension [X : Ordering](xs: Set[X])
+        def toNonEmptySet: Option[NonEmptySet[X]] = NonEmptySet.fromSet(xs.toSortedSet)
+        def toNonEmptySetUnsafe: NonEmptySet[X] = xs.toNonEmptySet.getOrElse {
+            throw new IllegalArgumentException("Cannot create NonEmptySet from empty set")
+        }
+        def toSortedSet: SortedSet[X] = SortedSet.from(xs)
+
+    extension [X](xs: NonEmptySet[X])
+        def ++(ys: Set[X])(using Ordering[X]): NonEmptySet[X] = ys.toNonEmptySet.fold(xs)(xs | _)
+
     /**
       * Take the cartesian product over the given input collections.
       *

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -143,13 +143,13 @@ package object looptrace {
         inline def apply(z: Int): PositiveInt = 
             inline if z <= 0 then compiletime.error("Non-positive integer where positive is required!")
             else (z: PositiveInt)
+        extension (n: PositiveInt)
+            def asNonnegative: NonnegativeInt = NonnegativeInt.unsafe(n)
         def either(z: Int): Either[String, PositiveInt] = maybe(z).toRight(s"Cannot refine as positive: $z")
         def maybe(z: Int): Option[PositiveInt] = (z > 0).option{ (z: PositiveInt) }
         def unsafe(z: Int): PositiveInt = either(z).fold(msg => throw new NumberFormatException(msg), identity)
         given posIntOrder(using intOrd: Order[Int]): Order[PositiveInt] = intOrd.contramap(identity)
         given posIntRW(using intRW: ReadWriter[Int]): ReadWriter[PositiveInt] = intRW.bimap(identity, _.int)
-        extension (n: PositiveInt)
-            def asNonnegative: NonnegativeInt = NonnegativeInt.unsafe(n)
     end PositiveInt
 
     /** Refinement for positive real values */

--- a/src/test/scala/PartitionRoisSuite.scala
+++ b/src/test/scala/PartitionRoisSuite.scala
@@ -12,9 +12,6 @@ import at.ac.oeaw.imba.gerlich.looptrace.PartitionIndexedDriftCorrectionRois.{ X
 /** Types and helpers for testing partitioning of regions of interest (ROIs) */
 trait PartitionRoisSuite extends LooptraceSuite:
     
-    /** Randomized, guaranteed-valid parser configuration (no column name collisions) */
-    given parserConfigArbitrary: Arbitrary[ParserConfig] = Arbitrary(genParserConfig)
-    
     /** Arbitrary point, index, and usability flag lifted into detected ROI data type value */
     given detectedRoiArbitrary(using arbComponents: Arbitrary[(RoiIndex, Point3D, Boolean)]): Arbitrary[DetectedRoi] = 
         arbComponents.fmap(DetectedRoi.apply.tupled)
@@ -28,28 +25,13 @@ trait PartitionRoisSuite extends LooptraceSuite:
     /** Arbitrary point, index, and lifted into accuracy ROI data type value */
     given accuracyRoiArbitrary: Arbitrary[RoiForAccuracy] = Arbitrary{ genSelectedRoi(RoiForAccuracy.apply) }
     
+    /* Arbitrary instances for (z, y, x) columns to parse */
     given xColArb: Arbitrary[XColumn] = Arbitrary{ Gen.alphaNumStr.suchThat(_.nonEmpty).map(XColumn.apply) }
     given yColArb: Arbitrary[YColumn] = Arbitrary{ Gen.alphaNumStr.suchThat(_.nonEmpty).map(YColumn.apply) }
     given zColArb: Arbitrary[ZColumn] = Arbitrary{ Gen.alphaNumStr.suchThat(_.nonEmpty).map(ZColumn.apply) }
 
-    /**
-     * Generate a legal/valid parsing configuration for bead ROIs partition
-     * 
-     * This function ensures that there's no column name collision for the parser configuration, 
-     * and that the values of each field are appropriately typed.
-     * 
-     * @return A generator of valid parser configurations
-     */
-    def genParserConfig: Gen[ParserConfig] = for {
-        x <- arbitrary[XColumn]
-        y <- Gen.alphaNumStr.suchThat(_ =!= x.get).map(YColumn.apply)
-        z <- Gen.alphaNumStr.suchThat(s => s =!= x.get && s =!= y.get).map(ZColumn.apply)
-        qc <- Gen.alphaNumStr.suchThat(s => s =!= x.get && s =!= y.get && s =!= z.get)
-        coordseq <- arbitrary[CoordinateSequence]
-    } yield ParserConfig(x, y, z, qcCol = qc, coordinateSequence = coordseq)
-
     /** Generate a point and an index, then lift these arguments into a (isomorphic) case class instance. */
-    def genSelectedRoi[R <: SelectedRoi](build: (RoiIndex, Point3D) => R): Gen[R] = for {
+    private def genSelectedRoi[R <: SelectedRoi](build: (RoiIndex, Point3D) => R): Gen[R] = for {
         i <- arbitrary[RoiIndex]
         p <- arbitrary[Point3D]
     } yield build(i, p)

--- a/src/test/scala/PartitionRoisSuite.scala
+++ b/src/test/scala/PartitionRoisSuite.scala
@@ -11,19 +11,16 @@ import at.ac.oeaw.imba.gerlich.looptrace.PartitionIndexedDriftCorrectionRois.{ X
 
 /** Types and helpers for testing partitioning of regions of interest (ROIs) */
 trait PartitionRoisSuite extends LooptraceSuite:
-    
+
     /** Arbitrary point, index, and usability flag lifted into detected ROI data type value */
-    given detectedRoiArbitrary(using arbComponents: Arbitrary[(RoiIndex, Point3D, Boolean)]): Arbitrary[DetectedRoi] = 
+    given detectedRoiArbitrary(using arbComponents: Arbitrary[(RoiIndex, Point3D, RoiFailCode)]): Arbitrary[DetectedRoi] = 
         arbComponents.fmap(DetectedRoi.apply.tupled)
     
-    /** Generator for detected ROI, fixing the usability flag as given */
-    def genDetectedRoiFixedUse = (p: Boolean) => arbitrary[DetectedRoi].map(_.copy(isUsable = p))
-
     /** Arbitrary point, index, and lifted into shifting ROI data type value */
-    given shiftingRoiArbitrary: Arbitrary[RoiForShifting] = Arbitrary{ genSelectedRoi(RoiForShifting.apply) }
+    given arbitraryForRoiForShifting: Arbitrary[RoiForShifting] = Arbitrary{ genSelectedRoi(RoiForShifting.apply) }
     
     /** Arbitrary point, index, and lifted into accuracy ROI data type value */
-    given accuracyRoiArbitrary: Arbitrary[RoiForAccuracy] = Arbitrary{ genSelectedRoi(RoiForAccuracy.apply) }
+    given arbitraryForRoiForAccuracy: Arbitrary[RoiForAccuracy] = Arbitrary{ genSelectedRoi(RoiForAccuracy.apply) }
     
     /* Arbitrary instances for (z, y, x) columns to parse */
     given xColArb: Arbitrary[XColumn] = Arbitrary{ Gen.alphaNumStr.suchThat(_.nonEmpty).map(XColumn.apply) }

--- a/src/test/scala/TestCartesianProduct.scala
+++ b/src/test/scala/TestCartesianProduct.scala
@@ -1,6 +1,6 @@
 package at.ac.oeaw.imba.gerlich.looptrace
 
-import scala.collection.SortedSet
+import scala.collection.immutable.SortedSet
 import cats.syntax.all.*
 import org.scalacheck.{ Arbitrary, Gen, Shrink }
 import org.scalacheck.Arbitrary.arbitrary

--- a/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
+++ b/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
@@ -764,7 +764,7 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
             Array("", ParserConfig.xCol.get, ParserConfig.yCol.get, ParserConfig.zCol.get, ParserConfig.qcCol),
             (p: Point3D) => Array(p.x.get, p.y.get, p.z.get).map(_.toString)
         )
-        val records = NonnegativeInt.indexed(rois).map{ (r, i) => i.toString +: getPointFields(r.centroid) :+ "" }
+        val records = rois.map{ roi => roi.index.get.toString +: getPointFields(roi.centroid) :+ "" }
         os.write(f, (header +: records).map(_.mkString(",") ++ "\n"))
     }
 

--- a/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
+++ b/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
@@ -566,7 +566,9 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
             (0 to 1).flatMap{ p => (0 to 2).map(p -> _) }
         ).toList.map((p, t) => PositionIndex.unsafe(p) -> FrameIndex.unsafe(t))
         def genDetected(lo: Int, hi: Int) = 
-            (_: List[PosFramePair]).traverse{ pt => genMixedUsabilityRoisEachSize(lo, hi).map(pt -> _) }
+            // Make all ROIs usable so that the math about how many will be realized (used) is easier; 
+            // in particular, we don't want that math dependent on counting the number of usable vs. unusable ROIs.
+            (_: List[PosFramePair]).traverse{ pt => genUsableRois(lo, hi).map(pt -> _) }
         def genArgs = for {
             numTooFewReqShifting <- Gen.oneOf(Gen.const(0), Gen.choose(1, posTimePairs.length))
             numTooFewReqAccuracy <- Gen.oneOf(Gen.const(0), Gen.choose(posTimePairs.length - numTooFewReqShifting, posTimePairs.length))

--- a/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
+++ b/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
@@ -743,9 +743,8 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
     
     /** Syntax additions on a detected ROI to set its usability flag */
     extension (roi: DetectedRoi)
-        def setUsability = (use: Boolean) => roi.copy(isUsable = use)
-        def setUsable: DetectedRoi = setUsability(true)
-        def setUnusable: DetectedRoi = setUsability(false)
+        def setUsable: DetectedRoi = roi.copy(isUsable = true)
+        def setUnusable: DetectedRoi = roi.copy(isUsable = false)
 
     /** Generate a pair of pairs of nonnegative integers such that the first pair isn't the same as the second. */
     def genDistinctNonnegativePairs: Gen[(PosFramePair, PosFramePair)] = 

--- a/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
+++ b/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
@@ -534,249 +534,15 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
         }
     }
 
+    test("Any case of ROI count fewer than absolute minimum triggers expected exception.") { pending }
+
+    test("Warnings file is correct and produced IF AND ONLY IF there is at least one case of too-few-ROIs.") { pending }
+
     test("When there are no accuracy ROIs available, a JSON file is stil written but is empty.") { pending }
 
-    // test("Integration: toggle for tolerance of insufficient shifting ROIs works.") {
-    //     /**
-    //      * In this test, we generate cases in which it's possible that either one or both datasets
-    //      * have sufficient ROI counts for the randomly generated shifting and accuracy ROI counts, 
-    //      * or the one or both of the datasets have insufficient ROIs for the shifting and/or 
-    //      * accuracy requests. The tolerance for insufficient shifting ROIs is also randomised, 
-    //      * and expected output files present, and expected contents, are accordingly adjusted.
-    //     */
-    //     import SmallDataSet.*
+    test("No unusable ROI is ever used.") { pending }
 
-    //     implicit def noShrink[A]: Shrink[A] = Shrink.shrinkAny[A]
-
-    //     type PF = PosFramePair
-    //     val N1 = input1.points.length
-    //     val N2 = input2.points.length
-
-    //     def genSampleSizes: Gen[(PositiveInt, PositiveInt)] = for {
-    //         numShifting <- Gen.choose(1, scala.math.min(N1, N2) - 1).map(PositiveInt.unsafe)
-    //         numAccuracy <- Gen.choose(1, scala.math.max(N1, N2) + 1).map(PositiveInt.unsafe)
-    //     } yield (numShifting, numAccuracy)
-        
-    //     def gen5PF = arbitrary[(PF, PF, PF, PF, PF)].suchThat{ case (a, b, c, d, e) => Set(a, b, c, d, e).size === 5 }
-        
-    //     given inputArb: Arbitrary[InputBundle] = Arbitrary{ Gen.oneOf(input1, input2) }
-    //     def genInputsWithPF = Gen.zip(arbitrary[(InputBundle, InputBundle, InputBundle, InputBundle, InputBundle)], gen5PF) map {
-    //         case ((in1, in2, in3, in4, in5), (pf1, pf2, pf3, pf4, pf5)) => ((pf1, in1), (pf2, in2), (pf3, in3), (pf4, in4), (pf5, in5))
-    //     }
-
-    //     def genInputsAndExpectation = for {
-    //         (numShifting, numAccuracy) <- genSampleSizes
-    //         (a@(pf1, in1), b@(pf2, in2), c@(pf3, in3), d@(pf4, in4), e@(pf5, in5)) <- genInputsWithPF
-    //         usedFrames = Set(pf1._2, pf2._2, pf3._2, pf4._2, pf5._2)
-    //         useOneAsRef <- Gen.oneOf(false, true)
-    //         refFrame <- (
-    //             if useOneAsRef 
-    //             then Gen.oneOf(usedFrames).map(_.some)
-    //             else Gen.option(arbitrary[FrameIndex]).suchThat(_.fold(true)(i => !usedFrames.contains(i)))
-    //             )
-    //         (fatal, nonfatal) = List(a, b, c, d, e).foldRight(List.empty[(PF, InputBundle, TooFewShifting)], List.empty[(PF, InputBundle, TooFewAccuracy)]) { 
-    //             case ((pf, in), (worse, bads)) => 
-    //                 if in.numUsable < numShifting then ((pf, in, TooFewShifting(numShifting, in.numUsable)) :: worse, bads)
-    //                 else if in.numUsable < numShifting + numAccuracy then 
-    //                     // dummy null partition here, since it should never be accessed (only care about the requested and realised counts)
-    //                     val err = TooFewAccuracy(null, numAccuracy, NonnegativeInt.unsafe(in.numUsable - numShifting))
-    //                     (worse, (pf, in, err) :: bads)
-    //                 else (worse, bads)
-    //             }
-    //         (expError, expSevere) = (fatal, refFrame) match {
-    //             case (Nil, _) => (None, None)
-    //             case (_, None) => (Exception(s"${fatal.size} (position, frame) pairs with problems.\n${fatal.map(t => t._1 -> t._3)}").some, None)
-    //             case (_, Some(rf)) => fatal.partition(_._1._2 === rf) match {
-    //                 case (Nil, tolerated) => (None, tolerated.map(t => t._1 -> t._3).some)
-    //                 case (untolerated, _) => (Exception(s"${untolerated.size} (position, frame) pairs with problems.\n${untolerated.map(t => t._1 -> t._3)}").some, None)
-    //             }
-    //         }
-    //         expWarn = (expError.isEmpty && nonfatal.nonEmpty).option{ nonfatal.map(t => t._1 -> t._3) }
-    //     } yield (List(a, b, c, d, e), numShifting, numAccuracy, refFrame, (expError, expSevere, expWarn))
-
-    //     forAll (genInputsAndExpectation, minSuccessful(1000)) { 
-    //         case (inputsWithPF, numShifting, numAccuracy, refFrame, (expError, expSevere, expWarn)) => 
-    //             withTempDirectory{ (tempdir: os.Path) =>
-    //                 inputsWithPF.foreach(writeBundle(tempdir).tupled) // Prep the data.
-    //                 expError match {
-    //                     case Some(exc) => assertThrows[Exception]{ workflow(tempdir, numShifting, numAccuracy, refFrame, None) }
-    //                     case None => 
-    //                         workflow(tempdir, numShifting, numAccuracy, refFrame, None)
-    //                         assertTooFewRoisFileContents(tempdir / "roi_partition_warnings.severe.json", expSevere)
-    //                         assertTooFewRoisFileContents(tempdir / "roi_partition_warnings.json", expWarn)
-    //                 }
-    //             }
-    //     }
-    // }
-
-    // test("Integration: shifting <= #(usable ROIs) < shifting + accuracy ==> warnings file correctly produced; #116") {
-    //     import SmallDataSet.*
-    //     given noShrink[A]: Shrink[A] = Shrink.shrinkAny[A]
-
-    //     def genInputs = for {
-    //         numShifting <- Gen.choose(1, maxRequestNum - 1).map(PositiveInt.unsafe)
-    //         numAccuracy <- Gen.choose(maxRequestNum - numShifting + 1, TooHighRoisNum).map(PositiveInt.unsafe)
-    //         maybeSubfolderName <- Gen.option(Gen.const("temporary_subfolder"))
-    //         pf1 <- arbitrary[PosFramePair]
-    //         pf2 <- arbitrary[PosFramePair].suchThat(_ =!= pf1)
-    //     } yield (numShifting, numAccuracy, maybeSubfolderName, pf1, pf2)
-
-    //     forAll (genInputs) { case (numShifting, numAccuracy, maybeSubfolderName, pf1, pf2) =>
-    //         withTempDirectory{ (tempdir: os.Path) =>
-    //             /* Setup the inputs. */
-    //             List(pf1 -> input1, pf2 -> input2).foreach(writeBundle(tempdir).tupled)
-    //             /* Check that the workflow creates the expected warnings file. */
-    //             val warningsFile = tempdir / "roi_partition_warnings.json"
-    //             os.exists(warningsFile) shouldBe false
-    //             workflow(inputRoot = tempdir, numShifting = numShifting, numAccuracy = numAccuracy)
-    //             os.isFile(warningsFile) shouldBe true
-    //         }
-    //     }
-    // }
-
-    // test("Integration: golden path's overall behavioral properties are correct.") {
-    //     import SmallDataSet.*
-    //     given noShrink[A]: Shrink[A] = Shrink.shrinkAny[A]
-
-    //     /** Generate shifting and accuracy counts that should yield no warnings and no errors. */
-    //     def genInputs = for {
-    //         coordseq <- arbitrary[CoordinateSequence]
-    //         numShifting <- Gen.choose(1, maxRequestNum - 1).map(PositiveInt.unsafe)
-    //         numAccuracy <- Gen.choose(1, maxRequestNum - numShifting).map(PositiveInt.unsafe)
-    //         maybeSubfolderName <- Gen.option(Gen.const("temporary_subfolder"))
-    //         pf1 <- arbitrary[PosFramePair]
-    //         pf2 <- arbitrary[PosFramePair].suchThat(_ =!= pf1)
-    //     } yield (coordseq, numShifting, numAccuracy, maybeSubfolderName, pf1, pf2)
-        
-    //     forAll (genInputs) {
-    //         case (coordseq, numShifting, numAccuracy, maybeSubfolderName, pf1, pf2) => 
-    //             withTempDirectory{ (tempdir: os.Path) =>
-    //                 /* Setup the inputs. */
-    //                 val roisFolder = maybeSubfolderName.fold(tempdir)(tempdir / _)
-    //                 os.makeDir.all(roisFolder)
-    //                 val roiFileParts = List(pf1 -> input1, pf2 -> input2).map { 
-    //                     case (pf, inputBundle) => 
-    //                         val fp = roisFolder / getInputFilename.tupled(pf)
-    //                         os.write(fp, inputBundle.lines.mkString("\n"))
-    //                         pf -> inputBundle.partition
-    //                     }.toMap
-                    
-    //                 workflow(inputRoot = roisFolder, numShifting = numShifting, numAccuracy = numAccuracy)
-    //                 val shiftingOutfolder = getOutputSubfolder(roisFolder)(Purpose.Shifting)
-    //                 val accuracyOutfolder = getOutputSubfolder(roisFolder)(Purpose.Accuracy)
-    //                 List(shiftingOutfolder, accuracyOutfolder).forall(os.isDir) shouldBe true
-                    
-    //                 val posFramePairs = List(pf1, pf2)
-    //                 val expShiftingOutfiles = posFramePairs.map{ case (p, f) => (p, f) -> getOutputFilepath(roisFolder)(p, f, Purpose.Shifting) }
-    //                 val expAccuracyOutfiles = posFramePairs.map{ case (p, f) => (p, f) -> getOutputFilepath(roisFolder)(p, f, Purpose.Accuracy) }
-    //                 given shiftingRoiRW: ReadWriter[RoiForShifting] = SelectedRoi.simpleShiftingRW(coordseq)
-    //                 given accuracyRoiRW: ReadWriter[RoiForAccuracy] = SelectedRoi.simpleAccuracyRW(coordseq)
-    //                 val obsShiftings = expShiftingOutfiles.map { case (pf, fp) => (pf, readJsonFile[List[RoiForShifting]](fp)) }.toMap
-    //                 val obsAccuracies = expAccuracyOutfiles.map { case (pf, fp) => pf -> readJsonFile[List[RoiForAccuracy]](fp) }.toMap
-                    
-    //                 val shiftingOutFiles = os.list(shiftingOutfolder)
-    //                 val accuracyOutFiles = os.list(accuracyOutfolder)
-    //                 shiftingOutFiles.length shouldBe posFramePairs.length
-    //                 accuracyOutFiles.length shouldBe posFramePairs.length
-    //                 shiftingOutFiles.toSet shouldEqual expShiftingOutfiles.map(_._2).toSet
-    //                 accuracyOutFiles.toSet shouldEqual expAccuracyOutfiles.map(_._2).toSet
-    //                 obsShiftings.keySet shouldEqual obsAccuracies.keySet
-    //                 obsShiftings.forall(_._2.length === numShifting) shouldBe true
-    //                 obsAccuracies.forall(_._2.length === numAccuracy) shouldBe true
-                    
-    //                 val byPosFrame = obsShiftings.map{ case (pf, shifting) => pf -> (shifting, obsAccuracies(pf)) }
-                    
-    //                 // Set of ROIs for shifting must have no overlap with ROIs for accuracy.
-    //                 byPosFrame.values.map{ case (shifting, accuracy) => 
-    //                     (shifting.map(_.index).toSet & accuracy.map(_.index).toSet) 
-    //                 } shouldEqual List.fill(posFramePairs.length)(Set()) // no intersection
-                    
-    //                 // Each selected ROI (shifting and accuracy) should have been in the usable pool, not unusable.
-    //                 byPosFrame.toList.map{ case (pf, (shifting, accuracy)) => 
-    //                     val delIdx = shifting.map(_.index).toSet
-    //                     val accIdx = accuracy.map(_.index).toSet
-    //                     val part = roiFileParts(pf)
-    //                     (delIdx.forall(part.usable.contains), !delIdx.exists(part.unusable.contains), accIdx.forall(part.usable.contains), !accIdx.exists(part.unusable.contains))
-    //                 } shouldEqual List.fill(posFramePairs.length)((true, true, true, true))
-                    
-    //                 // The coordinates of the ROI centroids must be preserved during the selection/partitioning.
-    //                 byPosFrame.toList.map{ case (pf, (shifting, accuracy)) => 
-    //                     val getPoint = roiFileParts(pf).getPointSafe
-    //                     shifting.filterNot(roi => roi.centroid.some === getPoint(roi.index)) -> accuracy.filterNot(roi => roi.centroid.some === getPoint(roi.index))
-    //                 } shouldEqual List.fill(posFramePairs.length)(List() -> List())
-
-    //                 // There should be no warnings, anywhere.
-    //                 PathHelpers.listPath(tempdir).filter(_.last === "roi_partition_warnings.json").isEmpty shouldBe true
-    //             }
-    //     }
-    // }
-
-    /** Bundles of test data to use for the integration-like tests here, doing more actual file I/O */
-    object SmallDataSet:
-        val TooHighRoisNum = 10000
-
-        final case class InputBundle(lines: List[String], partition: Partition):
-            final def points = partition.points
-            final def numUsable = NonnegativeInt.unsafe(partition.numUsable)
-        end InputBundle
-        
-        final case class Partition(points: List[Point3D], usable: Set[RoiIndex]):
-            require(points.nonEmpty, "No points for partition!")
-            require(usable.size > 1, "Need at least 2 usable ROIs!")
-            require(usable.forall(_.get < points.length), "Illegal usability indices!") // Ensure each index corresponds to a point.
-            final def getPointSafe = (i: RoiIndex) => Try{ points(i.get) }.toOption
-            final def numUsable = usable.size
-            final def unusable: Set[RoiIndex] = (0 to points.size).map(RoiIndex.unsafe).toSet -- usable
-        end Partition
-
-        def input1 = InputBundle(lines1, indexPartition1)
-        private def points1 = List(
-            (11.96875, 1857.9375, 1076.25),
-            (10.6, 1919.8, 1137.4),
-            (11.88, 1939.52, 287.36),
-            (11.5, 1942.0, 1740.625),
-            (11.35, 2031.0, 863.15),
-            (12.4, 6.4, 1151.5), 
-            (12.1, 8.1, 1709.5)
-            ).map(buildPoint.tupled)
-        private def indexPartition1 = Partition(points1, usable = Set(0, 2, 3, 4).map(RoiIndex.unsafe))
-        private def lines1 = """,label,centroid-0,centroid-1,centroid-2,max_intensity,area,fail_code
-            101,102,11.96875,1857.9375,1076.25,26799.0,32.0,
-            104,105,10.6,1919.8,1137.4,12858.0,5.0,i
-            109,110,11.88,1939.52,287.36,21065.0,25.0,
-            110,111,11.5,1942.0,1740.625,21344.0,32.0,
-            115,116,11.35,2031.0,863.15,19610.0,20.0,
-            116,117,12.4,6.4,1151.5,16028.0,10.0,y
-            117,118,12.1,8.1,1709.5,14943.0,10.0,i
-            """.split("\n").map(_.trim).toList
-        
-        def input2 = InputBundle(lines2, indexPartition2)
-        private def points2 = List(
-                (9.6875, 888.375, 1132.03125),
-                (10.16, 1390.94, 1386.96),
-                (9.3125, 1567.5, 87.40625),
-                (9.166666666666666, 1576.75, 18.0),
-                (9.0, 1725.4, 1886.8),
-                (9.0, 1745.6, 1926.1),
-                (8.875, 1851.25, 1779.5),
-                (9.708333333333334, 1831.625, 1328.0),
-                ).map(buildPoint.tupled)
-        private def indexPartition2 = Partition(points2, usable = Set(0, 1, 2, 3, 5, 7).map(RoiIndex.unsafe))
-        private def lines2 = """,label,centroid-0,centroid-1,centroid-2,max_intensity,area,fail_code
-            3,4,9.6875,888.375,1132.03125,25723.0,32.0,
-            20,21,10.16,1390.94,1386.96,33209.0,50.0,
-            34,35,9.3125,1567.5,87.40625,23076.0,32.0,
-            36,37,9.166666666666666,1576.75,18.0,16045.0,12.0,
-            41,42,9.0,1725.4,1886.8,12887.0,5.0,i
-            43,44,9.0,1745.6,1926.1,15246.0,10.0,
-            44,47,8.875,1851.25,1779.5,14196.0,8.0,i
-            46,45,9.708333333333334,1831.625,1328.0,22047.0,24.0,
-            """.split("\n").map(_.trim).toList
-        
-        def delimiter = Delimiter.CommaSeparator
-        def maxRequestNum = scala.math.min(indexPartition1.usable.size, indexPartition2.usable.size)
-        private def buildPoint(x: Double, y: Double, z: Double) = Point3D(XCoordinate(x), YCoordinate(y), ZCoordinate(z))
-    end SmallDataSet
+    test("ROI centroid coordinates and IDs are correctly preserved during partition.") { pending }
 
     /* *******************************************************************************
      * Ancillary types and functions
@@ -790,18 +556,6 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
         def setUsable: DetectedRoi = roi.copy(isUsable = true)
         def setUnusable: DetectedRoi = roi.copy(isUsable = false)
 
-    // def assertTooFewRoisFileContents[A](filepath: os.Path, expected: Option[List[(PosFramePair, A)]]) = {
-    //     expected match {
-    //         case None => os.exists(filepath) shouldBe false
-    //         case Some(pfTooFewPairs) => 
-    //             os.isFile(filepath) shouldBe true
-    //             val obs = readJsonFile[List[(PosFramePair, TooFewRois)]](filepath)
-    //             val exp = pfTooFewPairs.map{ case (pf, tooFew) => pf -> tooFew.problem }
-    //             obs.length shouldEqual exp.length
-    //             obs.toSet shouldEqual exp.toSet
-    //     }
-    // }
-
     def genDistinctNonnegativePairs: Gen[(PosFramePair, PosFramePair)] = 
         Gen.zip(genNonnegativePair, genNonnegativePair)
             .suchThat{ case (p1, p2) => p1 =!= p2 }
@@ -812,12 +566,6 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
     def getInputFilename(pos: PositionIndex, frame: FrameIndex): String = s"bead_rois__${pos.get}_${frame.get}.csv"
     
     def maxNumRoisSmallTests: ShiftingCount = ShiftingCount(20)
-
-    def writeBundle(folder: os.Path)(pf: PosFramePair, bundle: SmallDataSet.InputBundle): os.Path = {
-        val fp = folder / getInputFilename.tupled(pf)
-        os.write(fp, bundle.lines.mkString("\n"))
-        fp
-    }
 
     def writeMinimalInputRoisCsv(rois: List[DetectedRoi], f: os.Path): Unit = {
         val (header, getPointFields) = (


### PR DESCRIPTION
- Close #173 
- Update pipeline execution control doc after discussion w/ @TLSteinacker 
- Plotting spot counts for regional and for locus-specific FISH probes
- Update "bead_points" / `num_bead_points` to `num_bead_rois_for_drift_correction` (now both config key and attribute on `ImageHandler`)
- Label per-probe plots as "probe" rather than "timepoint" -- close #202 
- Various helpers and combinators for working with `Set`s (`collections.scala`) and with JSON data (`UJsonHelpers.scala`)
- Adding `failCode` to detected ROI type (`DetectedRoi`), preserving that value from the bead ROI generation phase