### PR TITLE
Ignore/skip image stacks with too few bead ROIs for drift correction

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,3 @@
 linters: with_defaults(
-  indentation_linter: intentation_linter(
-    intent = 4L      
-  )
-)
+  indentation_linter: indentation_linter(
+    indent = 4L))

--- a/analysis_ad_hoc/diagnose_offcenter.py
+++ b/analysis_ad_hoc/diagnose_offcenter.py
@@ -1,0 +1,83 @@
+from math import floor
+from pathlib import Path
+from typing import *
+import numpy as np
+import pandas as pd
+
+
+Interval = Tuple[int, int]
+Box = Tuple[Interval, Interval, Interval]
+Point = Tuple[float, float, float]
+
+
+def get_bbox(r: Mapping[str, Any]) -> Box:
+    z_box = (r["z_min"], r["z_max"])
+    y_box = (r["y_min"], r["y_max"])
+    x_box = (r["x_min"], r["x_max"])
+    return z_box, y_box, x_box
+
+
+down_to_int = lambda x: int(floor(x))
+
+
+def extract_subimage(img: np.ndarray, sides: Box) -> np.ndarray:
+    z, y, x = sides
+    return img[slice(*z), slice(*y), slice(*x)]
+
+
+def extract_for_roi(img: np.ndarray, df: pd.DataFrame, roi_id: int) -> np.ndarray:
+    row = row_to_map(df[df.roi_id == roi_id])
+    (z1, z2), (y1, y2), (x1, x2) = get_bbox(row)
+    bbox = ((down_to_int(z1), down_to_int(z2)), (down_to_int(y1), down_to_int(y2)), (down_to_int(x1), down_to_int(x2)))
+    return extract_subimage(img, sides=bbox)
+
+
+def get_center_from_regions(df, roi_id) -> Point:
+    row = row_to_map(df[df.index == roi_id])
+    return row["zc"], row["yc"], row["xc"]
+
+
+def get_center_from_extract(df, roi_id) -> Point:
+    row = row_to_map(df[df.roi_id == roi_id])
+    (z1, z2), (y1, y2), (x1, x2) = get_bbox(row)
+    return 0.5 * (z1 + z2), 0.5 * (y1 + y2), 0.5 * (x1 + x2)
+
+
+def row_to_map(r: pd.DataFrame) -> Mapping[str, Any]:
+    assert r.shape[0] == 1, f"Not exactly 1 row! {r.shape[0]}"
+    return {k: list(m.values())[0] for k, m in r.to_dict().items()}
+
+
+def get_npy_file_name(posname: str, roi_id: int, ref_frame: int) -> str:
+    return f"{posname}_{roi_id}_{ref_frame}.npy"
+
+
+
+
+
+# rois_of_interest = [10345, 10349, 10350, 10351]
+# time_of_interest = 57
+# pos_of_interest = "P0013.zarr"
+
+# experiment_root = Path(...)
+# analysis_folder = experiment_root / ...
+# diagnostics_folder = experiment_root / ...
+# old_spot_images_folder = experiment_root / ... / ...
+# rois = pd.read_csv(analysis_folder / ..., index_col=0)
+# rois = rois[(rois.position == pos_of_interest) & (rois.frame == time_of_interest)]
+# dcrois = pd.read_csv(analysis_folder / ..., index_col=0)
+# dcrois = dcrois[(dcrois.position == pos_of_interest) & (dcrois.frame == time_of_interest) & (dcrois.ref_frame == time_of_interest)]
+
+# all(get_center_from_regions(rois, i) == get_center_from_extract(dcrois, i) for i in rois_of_interest)
+
+# bigimg = np.load(experiment_root / ...)
+# imgs = {i: extract_for_roi(img=bigimg, df=dcrois, roi_id=i) for i in rois_of_interest}
+
+# new_spot_images_folder = diagnostics_folder / ...
+
+# def save_npy_file(arr: np.ndarray, roi_id: int) -> Path:
+#     fp = new_spot_images_folder / get_npy_file_name(posname=pos_of_interest, roi_id=roi_id, ref_frame=time_of_interest)
+#     np.save(fp, arr)
+#     return fp
+
+# new_spot_files = {i: save_npy_file(img, roi_id=i) for i, img in imgs.items()}

--- a/bin/cli/detect_spots.py
+++ b/bin/cli/detect_spots.py
@@ -8,9 +8,7 @@ EMBL Heidelberg
 
 import argparse
 from dataclasses import dataclass
-from enum import Enum
 import json
-import os
 from pathlib import Path
 from typing import *
 

--- a/bin/cli/extract_spots.py
+++ b/bin/cli/extract_spots.py
@@ -7,7 +7,6 @@ EMBL Heidelberg
 """
 
 import argparse
-import os
 
 from gertils import ExtantFile, ExtantFolder
 

--- a/bin/cli/run_processing_pipeline.py
+++ b/bin/cli/run_processing_pipeline.py
@@ -43,7 +43,7 @@ TRACING_QC_STAGE_NAME = "tracing_QC"
 
 class SpotType(Enum):
     REGIONAL = "regional"
-    LOCUS_SPECIFIC = "locus_specific"
+    LOCUS_SPECIFIC = "locus-specific"
 
 
 def partition_bead_rois(config_file: ExtantFile, images_folder: ExtantFolder):

--- a/bin/cli/run_processing_pipeline.py
+++ b/bin/cli/run_processing_pipeline.py
@@ -64,12 +64,6 @@ def partition_bead_rois(config_file: ExtantFile, images_folder: ExtantFolder):
         "--outputFolder",
         str(H.bead_rois_path),
     ]
-    if H.tolerate_too_few_rois:
-        cmd_parts.extend([
-            "--optimisationTestingMode",
-            "--referenceFrame", 
-            str(Drifter(H).reference_frame),
-        ])
     print(f"Running bead ROI partitioning: {' '.join(cmd_parts)}")
     subprocess.check_call(cmd_parts)
 

--- a/bin/cli/spot_counts_visualisation.R
+++ b/bin/cli/spot_counts_visualisation.R
@@ -128,7 +128,10 @@ if (opts$spot_file_type == kRegionalName) {
     # Create a side-by-side grouped barchart, with unfiltered count next to filtered count for each timepoint.
     unfilteredSpots$filter_status <- FALSE
     filteredSpots$filter_status <- TRUE
-    spotCountsCombined <- rbindlist(list(unfilteredSpots, filteredSpots))[, .(count = .N), by = list(filter_status, frame_name)]
+    spotCountsCombined <- rbindlist(list(
+        unfilteredSpots[, .(filter_status, frame_name)], 
+        filteredSpots[, .(filter_status, frame_name)]
+    ))[, .(count = .N), by = list(filter_status, frame_name)]
     combinedBarchart <- ggplot(spotCountsCombined, aes(x = as.factor(frame_name), y = count, fill = filter_status)) + 
         geom_bar(stat = "identity", position = "dodge") + 
         xlab("probe") + 

--- a/looptrace/Drifter.py
+++ b/looptrace/Drifter.py
@@ -345,7 +345,6 @@ def compute_fine_drifts(drifter: "Drifter") -> None:
                     print(f"WARNING: {get_no_partition_message(frame)}")
                     assert (pos_idx, frame) in pos_time_problems, \
                         f"No bead ROIs for fine DC for (FOV={pos_idx}, time={frame}), but no evidence of a problem there"
-                    # TODO: need to store 0 fine drift.
                     fine = (0.0, 0.0, 0.0)
                 else:
                     mov_img = drifter.get_moving_image(pos_idx=pos_idx, frame_idx=frame)
@@ -371,7 +370,6 @@ def compute_fine_drifts(drifter: "Drifter") -> None:
                     print(f"WARNING: {get_no_partition_message(frame)}")
                     assert (pos_idx, frame) in pos_time_problems, \
                         f"No bead ROIs for fine DC for (FOV={pos_idx}, time={frame}), but no evidence of a problem there"
-                    # TODO: need to store 0 fine drift.
                     fine = (0.0, 0.0, 0.0)
                 else:
                     mov_img = drifter.get_moving_image(pos_idx=pos_idx, frame_idx=frame)

--- a/looptrace/Drifter.py
+++ b/looptrace/Drifter.py
@@ -320,7 +320,11 @@ def compute_fine_drifts(drifter: "Drifter") -> None:
         bead_rois = drifter.image_handler.read_bead_rois_file_shifting(pos_idx=pos_idx, frame=drifter.reference_frame)
         
         if bead_rois.shape != beads_exp_shape:
-            raise Exception(f"Unexpected bead ROIs shape for reference (pos={pos_idx}, frame={frame})! ({bead_rois.shape}), expecting {beads_exp_shape}")
+            msg_base = f"Unexpected bead ROIs shape for reference (pos={pos_idx}, frame={drifter.reference_frame})! ({bead_rois.shape}), expecting {beads_exp_shape}"
+            if len(bead_rois.shape) == 2 and bead_rois.shape[1] == beads_exp_shape[1]:
+                print(f"WARNING: {msg_base}")
+            else:
+                raise Exception(msg_base)
         
         curr_position_rows = []
         if drifter.method_name == Methods.FIT_NAME.value:

--- a/looptrace/ImageHandler.py
+++ b/looptrace/ImageHandler.py
@@ -96,9 +96,7 @@ class ImageHandler:
     @property
     def _severe_bead_roi_partition_problems_file(self) -> Optional[ExtantFile]:
         fp = self.bead_rois_path / "roi_partition_warnings.severe.json"
-        if self.tolerate_too_few_rois:
-            return ExtantFile(fp) if fp.exists() else None
-        assert not fp.exists(), f"Severe warnings file exists but tolerance for problems is turned off: {fp}"
+        return ExtantFile(fp) if fp.exists() else None
 
     @property
     def position_frame_pairs_with_severe_problems(self) -> Set[Tuple[int, int]]:
@@ -107,7 +105,7 @@ class ImageHandler:
             return set()
         with open(fp.path, 'r') as fh:
             data = json.load(fh)
-        return {(obj["position"], obj["frame"]) for obj in data}
+        return {(obj["position"], obj["time"]) for obj in data}
 
     @property
     def decon_input_name(self) -> str:
@@ -214,10 +212,6 @@ class ImageHandler:
     @property
     def spot_input_name(self) -> str:
         return self.config['spot_input_name']
-    
-    @property
-    def tolerate_too_few_rois(self) -> bool:
-        return self.config.get("tolerate_too_few_rois", False)
 
     @property
     def traces_path(self) -> Path:

--- a/looptrace/SpotPicker.py
+++ b/looptrace/SpotPicker.py
@@ -120,6 +120,7 @@ class SpotDetectionParameters:
     detection_function: callable
     downsampling: int
     minimum_distance_between: NumberLike
+    # TODO: non-nullity requirement for crosstalk_channel is coupled to this condition, and this should be reflected in the types.
     subtract_beads: bool
     crosstalk_channel: Optional[int]
     crosstalk_frame: Optional[int]
@@ -473,7 +474,7 @@ class SpotPicker:
                     bead_img = self.images[pos_index][frame, crosstalk_ch, ::spot_ds, ::spot_ds, ::spot_ds].compute()
                     img, orig = ip.subtract_crosstalk(source=img, bleed=bead_img, threshold=0)
 
-                spot_props, filt_img, _ = detect_func(img, spot_threshold[i], min_dist = min_dist)
+                spot_props, filt_img, _ = detect_func(img, spot_threshold[i])
                 spot_props['position'] = preview_pos
                 spot_props = spot_props.reset_index().rename(columns={'index':'roi_id_pos'})
 

--- a/looptrace/SpotPicker.py
+++ b/looptrace/SpotPicker.py
@@ -642,7 +642,7 @@ class SpotPicker:
         
         print(f"Writing spot image extraction skip reasons file: {self.extraction_skip_reasons_json_file}")
         with open(self.extraction_skip_reasons_json_file, 'w') as fh:
-            json.dump(skip_spot_image_reasons, fh)
+            json.dump(skip_spot_image_reasons, fh, indent=2)
 
         return self.spot_images_path
 

--- a/looptrace/image_processing_functions.py
+++ b/looptrace/image_processing_functions.py
@@ -23,6 +23,7 @@ from skimage.filters import gaussian, threshold_otsu
 from skimage.morphology import white_tophat, ball, remove_small_objects
 from skimage.measure import regionprops_table
 
+from looptrace.numeric_types import NumberLike
 from looptrace.wrappers import phase_xcor
 
 logger = logging.getLogger()
@@ -259,15 +260,15 @@ def center_crop_embryo(embryo_stack, size, center=None):
     return out
 
 
-def detect_spots(input_img, spot_threshold=20, expand_px=10):
+def detect_spots(input_img, spot_threshold: NumberLike, expand_px: int = 10):
     """Spot detection by difference of Gaussians filter
 
     Arguments
     ---------
     img : ndarray
         Input 3D image
-    spot_threshold : int or float
-        Threshold to use for spots. Defaults to 20.
+    spot_threshold : NumberLike
+        Threshold to use for spots
     expand_px : int
         Number of pixels by which to expand contiguous subregion, 
         up to point of overlap with neighboring subregion of image
@@ -301,15 +302,15 @@ def detect_spots(input_img, spot_threshold=20, expand_px=10):
     return spot_props, img, labels
 
 
-def detect_spots_int(input_img, spot_threshold=500, expand_px=1):
+def detect_spots_int(input_img, spot_threshold: NumberLike, expand_px: int = 1):
     """Spot detection by intensity filter
 
     Arguments
     ---------
     img : ndarray
         Input 3D image
-    spot_threshold : int or float
-        Threshold to use for spots. Defaults to 500.
+    spot_threshold : NumberLike
+        Threshold to use for spots
     expand_px : int
         Number of pixels by which to expand contiguous subregion, 
         up to point of overlap with neighboring subregion of image

--- a/src/main/scala/LabelAndFilterRois.scala
+++ b/src/main/scala/LabelAndFilterRois.scala
@@ -142,13 +142,13 @@ object LabelAndFilterRois:
                 .required()
                 .action((h, c) => c.copy(extantOutputHandler = h))
                 .text("How to handle writing output when target already exists"),
-            opt[Unit]("--noRegionGrouping")
+            opt[Unit]("noRegionGrouping")
                 .action((_, c) => c.copy(noRegionGrouping = true))
                 .text("Specify that proximity consideration / neighbor finding is to be done among ALL regional spots."),
-            opt[List[ProbeGroup]]("--proximityPermissions")
+            opt[List[ProbeGroup]]("proximityPermissions")
                 .action((groups, c) => c.copy(proximityPermissions = groups.some))
                 .text("List-of-lists--or path to file specifying one--grouping regional barcode timepoints for which to permit proximity"),
-            opt[List[ProbeGroup]]("--proximityProhibitions")
+            opt[List[ProbeGroup]]("proximityProhibitions")
                 .action((groups, c) => c.copy(proximityProhibitions = groups.some))
                 .text("List-of-lists--or path to file specifying one--grouping regional barcode timepoints for which to prohibit proximity"),
         )

--- a/src/main/scala/LabelAndFilterRois.scala
+++ b/src/main/scala/LabelAndFilterRois.scala
@@ -355,7 +355,7 @@ object LabelAndFilterRois:
       * @param simplify How to get from a more complex value `B` to a simpler `A`
       * @return A mapping from item to set of proximal (closer than given distance threshold) neighbors, omitting each item with no neighbors
       */
-    def buildNeighborsLookupKeyed[B, A : Order, K : Order](
+    private[looptrace] def buildNeighborsLookupKeyed[B, A : Order, K : Order](
         kvPairs: Iterable[(K, B)], usePair: (B, B) => Boolean, getPoint: A => Point3D, minDist: DistanceThreshold, simplify: B => A
         ): Map[A, NonEmptySet[A]] = 
         import ProximityComparable.proximal

--- a/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
+++ b/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
@@ -449,7 +449,7 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
                     /* Pretest and workflow execution */
                     val warningsFile = tempdir / "roi_partition_warnings.json"
                     os.exists(warningsFile) shouldBe false
-                    workflow(tempdir, reqShifting, reqAccuracy, None, None)
+                    workflow(tempdir, reqShifting, reqAccuracy, None)
                     /* Check the effect of having run the workflow */
                     // First, check the existence of the warnings file and parse it.
                     os.exists(warningsFile) shouldBe true
@@ -497,7 +497,7 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
                 val accuracyFolder = getOutputSubfolder(tempdir)(Purpose.Accuracy)
                 os.exists(shiftingFolder) shouldBe false
                 os.exists(accuracyFolder) shouldBe false
-                workflow(tempdir, reqShifting, reqAccuracy, None, None)
+                workflow(tempdir, reqShifting, reqAccuracy, None)
                 /* Make actual output assertions. */
                 val expFilesShifting = ptRoisPairs.map{
                     case ((p, t), _) => (p -> t) -> getOutputFilepath(tempdir)(p, t, Purpose.Shifting)
@@ -550,7 +550,7 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
                 /* Make actual output assertions. */
                 // First, the expected exception should occur.
                 val exception = intercept[RoisSplit.TooFewShiftingException]{
-                    workflow(tempdir, numReqShifting, numReqAccuracy, None, None)
+                    workflow(tempdir, numReqShifting, numReqAccuracy, None)
                 }
                 // Second, the expected exception should have the correct (FOV, time) fail points.
                 val obsBadPosTimePairs = exception.errors.map(_._1).toList
@@ -591,7 +591,7 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
                 val warningsFile = tempdir / "roi_partition_warnings.json"
                 os.exists(warningsFile) shouldBe false
                 /* Run the workflow */
-                workflow(tempdir, numReqShifting, numReqAccuracy, None, None)
+                workflow(tempdir, numReqShifting, numReqAccuracy, None)
                 /* Make actual output assertions. */
                 tooFew match {
                     case Nil => os.exists(warningsFile) shouldBe false
@@ -649,7 +649,7 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
                 val expAccuracyFiles = allFovTimeRois.map{ case ((p, t), _) => (p -> t) -> getOutputFilepath(tempdir)(p, t, Purpose.Accuracy) }
                 expAccuracyFiles.exists((_, f) => os.exists(f)) shouldBe false
                 /* Then, execute workflow. */
-                workflow(tempdir, numReqShifting, numReqAccuracy, None, None)
+                workflow(tempdir, numReqShifting, numReqAccuracy, None)
                 /* Finally, make assertions. */
                 expAccuracyFiles.filterNot((_, f) => os.isFile(f)) shouldEqual List()
                 given roiReader: Reader[RoiForAccuracy] = simpleAccuracyRW(ParserConfig.coordinateSequence)
@@ -691,7 +691,7 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
                 }
                 expAllOutFiles.flatMap(_._2).filter(os.isFile) shouldEqual List()
                 /* Run the workflow and find the output files. */
-                workflow(tempdir, numShifting, numAccuracy, None, None)
+                workflow(tempdir, numShifting, numAccuracy, None)
                 val obsFilesShifting = os.list(getOutputSubfolder(tempdir)(Purpose.Shifting)).filter(os.isFile).toSet
                 val obsFilesAccuracy = os.list(getOutputSubfolder(tempdir)(Purpose.Accuracy)).filter(os.isFile).toSet
                 

--- a/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
+++ b/src/test/scala/TestPartitionIndexedDriftCorrectionRois.scala
@@ -526,7 +526,7 @@ class TestPartitionIndexedDriftCorrectionRois extends AnyFunSuite, ScalacheckSui
         }
     }
 
-    test("Any case of ROI count fewer than absolute minimum triggers expected exception.") {
+    test("ROI counts fewer than absolute minimum result in expected warnings.") {
         given noShrink[A]: Shrink[A] = Shrink.shrinkAny[A]
         val posTimePairs = Random.shuffle(
             (0 to 1).flatMap{ p => (0 to 2).map(p -> _) }


### PR DESCRIPTION
- Fix linter configuration for `R`
- Add tools for diagnostics of off-center spot images for tracing 
- Fix bug in spot counts visualisation, related to dimensional (column count) mismatch b/w filtered and unfiltered tables/files
- Always tolerate too-few-beads for drift correction (#222 / #173)
- Nicer formatting for file with messages about skipped (FOV, time) image stacks for tracing image extraction
- Remove default for spot detection threshold, make it required
- Fix CLI options for regional barcode grouping for proximity filtering (#198 - related)

Close #222 
Close #198 