### PR TITLE
Update R, fix regional spot counts visualisation invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get update -y && \
     update-alternatives --config gcc && \
     apt-get install git wget libz-dev libbz2-dev liblzma-dev -y && \
     apt-get install cuda-compat-11-4 -y && \
-    apt-get install r-base -y && \
-    R -e "install.packages(c('argparse', 'data.table', 'ggplot2', 'stringi'), dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
     apt-get install vim -y
 
 # Copy repo code, to be built later.
@@ -25,6 +23,13 @@ RUN mkdir /looptrace
 WORKDIR /looptrace
 COPY . /looptrace
 RUN mv /looptrace/target/scala-3.3.1/looptrace-assembly-0.2.0-SNAPSHOT.jar /looptrace/looptrace
+
+# Install new-ish R and necessary packages.
+RUN echo "Installing R..." && \
+    /bin/bash /looptrace/setup_image/allow_new_R.sh && \
+    apt-get install r-base -y && \
+    R -e "install.packages(c('argparse', 'data.table', 'ggplot2', 'stringi'), dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
+    echo "Installed R!"
 
 # Install minimal Java 21 runtime, in updates repo for Ubuntu 20 (focal) as of 2024-01-19.
 RUN apt-get update -y && \

--- a/bin/cli/run_processing_pipeline.py
+++ b/bin/cli/run_processing_pipeline.py
@@ -149,7 +149,7 @@ def plot_spot_counts(config_file: ExtantFile, spot_type: "SpotType") -> None:
     if spot_type == SpotType.REGIONAL:
         unfiltered = H.raw_spots_file
         filtered = H.proximity_filtered_spots_file_path
-        probe_name_extra = ["--probe-names", " ".join(H.frame_names)]
+        probe_name_extra = ["--probe-names"] + H.frame_names
     elif spot_type == SpotType.LOCUS_SPECIFIC:
         unfiltered = H.traces_file_qc_unfiltered
         filtered = H.traces_file_qc_filtered

--- a/bin/cli/spot_counts_visualisation.R
+++ b/bin/cli/spot_counts_visualisation.R
@@ -16,8 +16,16 @@ kSpotCountPrefix <- "spot_counts"
 #   spots_table: data table with regional spots data
 #   probe_names: ordered list of names to give the imaging timepoints
 addProbeNames <- function(spots_table, probe_names) {
-    if ("frame_name" %in% colnames(spots_table)) { stop("Table alread contains column for probe names!") }
-    spots_table$frame_name <- sapply(spots_table$frame, function(i) probe_names[i + 1])
+    if ("frame_name" %in% colnames(spots_table)) { stop("Table already contains column for probe names!") }
+    probe_index <- (spots_table$frame + 1)
+    if ( ! all(probe_index %in% (1:length(probe_names))) ) {
+        stop(sprintf(
+            "Can't index (1-based, inclusive) into vector of %s probe names with these values: %s", 
+            length(probe_names), 
+            paste0(Filter(function(i) !(i %in% (1:length(probe_names))) , unique(probe_index)), collapse = ", ")
+            ))
+    }
+    spots_table$frame_name <- sapply(probe_index, function(i) probe_names[i])
     spots_table
 }
 

--- a/setup_image/allow_new_R.sh
+++ b/setup_image/allow_new_R.sh
@@ -1,3 +1,4 @@
+# Source: https://cloud.r-project.org/bin/linux/ubuntu/
 # update indices
 apt update -qq
 # install two helper packages we need

--- a/setup_image/allow_new_R.sh
+++ b/setup_image/allow_new_R.sh
@@ -1,0 +1,10 @@
+# update indices
+apt update -qq
+# install two helper packages we need
+apt install --no-install-recommends software-properties-common dirmngr
+# add the signing key (by Michael Rutter) for these repos
+# To verify key, run gpg --show-keys /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc 
+# Fingerprint: E298A3A825C0D65DFD57CBB651716619E084DAB9
+wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+# add the R 4.0 repo from CRAN -- adjust 'focal' to 'groovy' or 'bionic' as needed
+add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"


### PR DESCRIPTION
- Update `R` to 4.2.3, and packages accordingly
- Safety check on probe index-to-name mapping for regional spot counts visualisation
- Fix pipeline's invocation of regional spot counts visualisation to close #233 