### PR TITLE
Match locus-specific points structure to images structure

### DIFF
--- a/bin/cli/run_processing_pipeline.py
+++ b/bin/cli/run_processing_pipeline.py
@@ -255,7 +255,7 @@ def drift_correct_nuclei(config_file: ExtantFile, images_folder: ExtantFolder) -
     return N.coarse_drift_correction_workflow()
 
 
-def visualise_regional_spots(config_file: ExtantFile, images_folder: ExtantFolder):
+def run_regional_spot_visualisation(config_file: ExtantFile, images_folder: ExtantFolder):
     return visualise_regional_spots(
         config_file=config_file, 
         images_folder=images_folder,
@@ -314,7 +314,7 @@ class LooptracePipeline(pypiper.Pipeline):
             ("spot_counts_visualisation__locus_specific", plot_spot_counts, take1_with_spot_type(SpotType.LOCUS_SPECIFIC)), 
             ("pairwise_distances__locus_specific", compute_locus_pairwise_distances, take1),
             ("pairwise_distances__regional", compute_region_pairwise_distances, take1),
-            ("regional_spots_visualisation", visualise_regional_spots, take2),
+            ("regional_spots_visualisation", run_regional_spot_visualisation, take2),
             ("locus_specific_spots_visualisation_data_prep", prep_locus_specific_spots_visualisation, take2),
         ]
 

--- a/bin/cli/run_processing_pipeline.py
+++ b/bin/cli/run_processing_pipeline.py
@@ -314,8 +314,8 @@ class LooptracePipeline(pypiper.Pipeline):
             ("spot_counts_visualisation__locus_specific", plot_spot_counts, take1_with_spot_type(SpotType.LOCUS_SPECIFIC)), 
             ("pairwise_distances__locus_specific", compute_locus_pairwise_distances, take1),
             ("pairwise_distances__regional", compute_region_pairwise_distances, take1),
-            ("regional_spots_visualisation", run_regional_spot_visualisation, take2),
             ("locus_specific_spots_visualisation_data_prep", prep_locus_specific_spots_visualisation, take2),
+            ("regional_spots_visualisation", run_regional_spot_visualisation, take2),
         ]
 
     def stages(self) -> List[Callable]:

--- a/bin/cli/spot_counts_visualisation.R
+++ b/bin/cli/spot_counts_visualisation.R
@@ -46,8 +46,19 @@ buildCountsHeatmap <- function(spots_table) {
 #   spot_type_name: either 'regional' or 'locus_specific', indicating the type of spots data passed
 #   output_folder: path to folder in which to place output
 plotAndWriteToFile <- function(spots_table, filt_type, spot_type_name, output_folder) {
-    if ( ! (filt_type %in% c("unfiltered", "proximity-filtered", "nuclei-filtered"))) {
-        stop("Illegal value for filtered/not argument: ", filt_type)
+    if (spot_type_name == kRegionalName) {
+        legal_names <- c("unfiltered", "proximity-filtered", "nuclei-filtered")
+    } else if (spot_type_name == kLocusSpecificName) {
+        legal_names <- c("unfiltered", "filtered")
+    } else {
+        stop("Illegal value for spot_type_name: ", spot_type_name)
+    }
+    if ( ! (filt_type %in% legal_names)) {
+        stop(sprintf(
+            "For spot_type_name %s, illegal value for filtered/not argument: %s", 
+            spot_type_name, 
+            filt_type
+            ))
     }
     p <- buildCountsHeatmap(spots_table)
     p <- p + ggtitle(sprintf("Counts of %s spots, %s", spot_type_name, filt_type))

--- a/bin/cli/visualise_detected_spots.py
+++ b/bin/cli/visualise_detected_spots.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     position_subset_spec = parser.add_mutually_exclusive_group()
     position_subset_spec.add_argument("--positions", nargs="*", type=int, help="Indices (0-based) of positions to use, otherwise use all.")
     position_subset_spec.add_argument("--num-positions", type=int, help="Number of positions to use")
-    parser.add_argument("--no-interaction", action="store_true", help="Do not do interactive image viewing.")
+    parser.add_argument("--interactive", action="store_true", help="Do interactive image viewing.")
     parser.add_argument("--save-projections", action="store_true", help="Save (max-z-projected) 2D images with bounding boxes.")
     args = parser.parse_args()
     if args.positions:
@@ -137,7 +137,7 @@ if __name__ == "__main__":
         config_file=args.config_path, 
         images_folder=args.image_path, 
         image_save_path=args.image_save_path, 
-        interactive=not args.no_interaction,
+        interactive=args.interactive,
         save_projections=args.save_projections, 
         positions_to_use=positions,
         )

--- a/docs/pipeline-execution-control-and-restart.md
+++ b/docs/pipeline-execution-control-and-restart.md
@@ -58,5 +58,5 @@ Below are the sequential pipeline stage names.
 * spot_counts_visualisation__locus_specific
 * pairwise_distances__locus_specific
 * pairwise_distances__regional
-* regional_spots_visualisation
 * locus_specific_spots_visualisation_data_prep
+* regional_spots_visualisation

--- a/looptrace/Tracer.py
+++ b/looptrace/Tracer.py
@@ -368,10 +368,13 @@ def apply_fine_scale_drift_correction(traces: pd.DataFrame) -> pd.DataFrame:
 
 def apply_pixels_to_nanometers(traces: pd.DataFrame, z_nm_per_px: float, xy_nm_per_px: float) -> pd.DataFrame:
     """Add columns for distance in nanometers, based on pixel-to-nanometer conversions."""
-    z_cols = [BOX_Z_COL, "z", "sigma_z"]
-    xy_cols = [BOX_Y_COL, BOX_X_COL, "y", "x", "sigma_xy"]
-    traces[z_cols] = traces[z_cols] * z_nm_per_px
-    traces[xy_cols] = traces[xy_cols] * xy_nm_per_px
+    simple_z = [BOX_Z_COL, "sigma_z"]
+    simple_xy = [BOX_Y_COL, BOX_X_COL, "sigma_xy"]
+    traces[simple_z] = traces[simple_z] * z_nm_per_px
+    traces[simple_xy] = traces[simple_xy] * xy_nm_per_px
+    traces["z"] = traces["z_px_dc"] * z_nm_per_px
+    traces["y"] = traces["y_px_dc"] * xy_nm_per_px
+    traces["x"] = traces["x_px_dc"] * xy_nm_per_px
     return traces
 
 

--- a/looptrace/Tracer.py
+++ b/looptrace/Tracer.py
@@ -125,7 +125,8 @@ class Tracer:
     @property
     def images(self) -> Iterable[np.ndarray]:
         """Iterate over the small, single spot images for tracing (1 per timepoint per ROI)."""
-        for fn in self._iterate_over_spot_filenames():
+        _, keyed_filenames = _prep_npz_to_zarr(self._images_wrapper)
+        for _, fn in keyed_filenames:
             yield self._images_wrapper[fn]
 
     @property


### PR DESCRIPTION
Finishing off #192 / #64

For each position / FOV, take the pixel coordinates of the center of the Gaussian fit to data extracted from a single ROI for a single timepoint. 
Since there are many ROIs per FOV, however, and many timepoints per ROI (e.g., 300 ROIs in a FOV, and 60 timepoints per ROI), this is a long list of 3D coordinates per FOV. To match the structure of spot images for tracing that we want to view in napari, we need to nest these points, stacking the 3-element arrays representing single point coordinates. We stack the coordinates for each timepoint in a ROI, then stack all ROIs per FOV. Then we have the proper structure for a points layer to overlay our image layer, 1 per FOV.

Includes random other patch fixes to pipeline components changed recently