### PR TITLE
Preserve correct FOV-based names for nuclear masks when a field of view is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.0] - 2024-07-12
+
+### Fixed
+* Nuclear mask ZARR arrays will now have names matched to their original field of view name, not simply contiguous initial subsequence of natural numbers. See [Issue 344](https://github.com/gerlichlab/looptrace/issues/344).
+
+### Changed
+* The signature of `image_io.images_to_ome_zarr` changes to permit only a collection of per-field-of-view arrays, and the function no longer accepts a data type argument but rather infers the data type from the given data, raising an error if the same type isn't inferred for every array in the given collection.
+
 ## [v0.7.0] - 2024-07-11
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -y && \
 RUN mkdir /looptrace
 WORKDIR /looptrace
 COPY . /looptrace
-RUN mv /looptrace/target/scala-3.4.2/looptrace-assembly-0.7.0.jar /looptrace/looptrace
+RUN mv /looptrace/target/scala-3.4.2/looptrace-assembly-0.8.0.jar /looptrace/looptrace
 
 # Install new-ish R and necessary packages.
 RUN echo "Installing R..." && \

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val primaryJavaVersion = "11"
 val primaryOs = "ubuntu-latest"
 val isPrimaryOsAndPrimaryJavaTest = s"runner.os == '$primaryOs' && runner.java-version == '$primaryJavaVersion'"
 ThisBuild / scalaVersion     := "3.4.2"
-ThisBuild / version          := "0.7.0"
+ThisBuild / version          := "0.8.0"
 ThisBuild / organization     := orgName
 ThisBuild / organizationName := "Gerlich Group, IMBA, OEAW"
 

--- a/looptrace/ImageHandler.py
+++ b/looptrace/ImageHandler.py
@@ -471,7 +471,7 @@ class ImageHandler:
     
     def read_images(self, is_eligible: PathFilter = lambda p: p.name != SPOT_IMAGES_SUBFOLDER and not ignore_path(p)):
         '''
-        Function to load existing images from the input folder, and them into a dictionary (self.images{}),
+        Function to load existing images from the input folder, and then into a dictionary (self.images{}),
         with folder name or image name (without extensions) as keys, images as values.
         Standardized to either folders with OME-ZARR, single NPY files or NPZ collections.
         More can be added as needed.

--- a/looptrace/NucDetector.py
+++ b/looptrace/NucDetector.py
@@ -269,7 +269,7 @@ class NucDetector:
         if self.do_in_3d:
             for pos_name, subimg in tqdm.tqdm(name_img_pairs):
                 image_io.single_position_to_zarr(
-                    subimg, 
+                    images=subimg, 
                     path=self.nuclear_segmentation_images_path, 
                     name=self.SEGMENTATION_IMAGES_KEY, 
                     pos_name=pos_name, 
@@ -315,7 +315,7 @@ class NucDetector:
             # See: https://github.com/gerlichlab/looptrace/issues/245
             bit_depth: image_io.PixelArrayBitDepth = image_io.PixelArrayBitDepth.unsafe_for_array(mask)
             image_io.single_position_to_zarr(
-                mask, 
+                images=mask, 
                 path=self.nuclear_masks_path, 
                 name=self.MASKS_KEY, 
                 pos_name=pos, 

--- a/looptrace/NucDetector.py
+++ b/looptrace/NucDetector.py
@@ -365,7 +365,7 @@ class NucDetector:
         saving_prefix = "Overwriting existing nuclear segmentations" if self.nuclear_masks_path.exists() else "Saving nuclear segmentations"
         print(f"{saving_prefix}: {self.nuclear_masks_path}")
         # TODO: need to adjust axes argument probably.
-        # See: https://github.com/gerlichlab/looptrace/issues/245
+        # See: https://github.com/gerlichlab/looptrace/issues/247
         bit_depths: set[image_io.PixelArrayBitDepth] = {image_io.PixelArrayBitDepth.unsafe_for_array(m) for m in masks}
         if len(bit_depths) > 1:
             raise RuntimeError(f"Multiple ({len(bit_depths)}) determined for masks: {', '.join(d.name for d in bit_depths)}")
@@ -387,7 +387,7 @@ class NucDetector:
             print("Saving classifications...")
             self.image_handler.images[self.CLASSES_KEY] = nuc_class
             # TODO: need to adjust axes argument probably.
-            # See: https://github.com/gerlichlab/looptrace/issues/245
+            # See: https://github.com/gerlichlab/looptrace/issues/247
             image_io.images_to_ome_zarr(images=nuc_class, path=self.nuc_classes_path, name=self.CLASSES_KEY, axes=ome_zarr_axes, dtype=np.uint16, chunk_split=(1, 1))
 
         return self.nuclear_masks_path

--- a/looptrace/NucDetector.py
+++ b/looptrace/NucDetector.py
@@ -368,7 +368,7 @@ class NucDetector:
         # See: https://github.com/gerlichlab/looptrace/issues/247
         bit_depths: set[image_io.PixelArrayBitDepth] = {image_io.PixelArrayBitDepth.unsafe_for_array(m) for m in masks}
         if len(bit_depths) > 1:
-            raise RuntimeError(f"Multiple ({len(bit_depths)}) determined for masks: {', '.join(d.name for d in bit_depths)}")
+            raise RuntimeError(f"Multiple ({len(bit_depths)}) bit depths determined for masks: {', '.join(d.name for d in bit_depths)}")
         image_io.images_to_ome_zarr(
             images=masks, 
             path=self.nuclear_masks_path, 

--- a/looptrace/NucDetector.py
+++ b/looptrace/NucDetector.py
@@ -373,7 +373,7 @@ class NucDetector:
         image_io.images_to_ome_zarr(
             images=masks, 
             path=self.nuclear_masks_path, 
-            name=self.MASKS_KEY, 
+            data_name=self.MASKS_KEY, 
             axes=zarr_axes, 
             dtype=bit_depth.value, 
             chunk_split=(1, 1),
@@ -393,7 +393,7 @@ class NucDetector:
             image_io.images_to_ome_zarr(
                 images=nuc_class, 
                 path=self.nuc_classes_path, 
-                name=self.CLASSES_KEY, 
+                data_name=self.CLASSES_KEY, 
                 axes=zarr_axes, 
                 dtype=np.uint16, 
                 chunk_split=(1, 1),

--- a/looptrace/NucDetector.py
+++ b/looptrace/NucDetector.py
@@ -427,20 +427,6 @@ class NucDetector:
         return outfile
 
 
-def _mask_to_binary(mask):
-    '''Converts masks from nuclear segmentation to masks with 
-    single pixel background between separate, neighbouring features.
-
-    Args:
-        masks ([np array]): Detected nuclear masks (label image)
-
-    Returns:
-        [np array]: Masks with single pixel seperation beteween neighboring features.
-    '''
-    masks_no_bound = np.where(find_boundaries(mask) > 0, 0, mask)
-    return masks_no_bound
-
-
 def _mitotic_cell_extra_seg(nuc_image, nuc_mask):
     '''Performs additional mitotic cell segmentation on top of an interphase segmentation (e.g. from CellPose).
     Assumes mitotic cells are brighter, unsegmented objects in the image.

--- a/looptrace/NucDetector.py
+++ b/looptrace/NucDetector.py
@@ -369,12 +369,16 @@ class NucDetector:
         bit_depths: set[image_io.PixelArrayBitDepth] = {image_io.PixelArrayBitDepth.unsafe_for_array(m) for m in masks}
         if len(bit_depths) > 1:
             raise RuntimeError(f"Multiple ({len(bit_depths)}) bit depths determined for masks: {', '.join(d.name for d in bit_depths)}")
+        try:
+            unique_bit_depth: image_io.PixelArrayBitDepth = next(iter(bit_depths))
+        except StopIteration as e:
+            raise Exception("No bit depth determined with which to save nuclear masks; are there no masks or nuclear images?") from e
         image_io.images_to_ome_zarr(
             images=masks, 
             path=self.nuclear_masks_path, 
             name=self.MASKS_KEY, 
             axes=ome_zarr_axes, 
-            dtype=next(iter(bit_depths)).value, 
+            dtype=unique_bit_depth.value, 
             chunk_split=(1, 1),
         )
         

--- a/looptrace/__init__.py
+++ b/looptrace/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 # This is put into place by the docker build, as declared in the Dockerfile.
-LOOPTRACE_JAR_PATH = importlib.resources.files(__name__).joinpath("looptrace-assembly-0.7.0.jar")
+LOOPTRACE_JAR_PATH = importlib.resources.files(__name__).joinpath("looptrace-assembly-0.8.0.jar")
 LOOPTRACE_JAVA_PACKAGE = "at.ac.oeaw.imba.gerlich.looptrace"
 
 MAX_DISTANCE_SPOT_FROM_REGION_NAME = "max_dist"

--- a/looptrace/image_io.py
+++ b/looptrace/image_io.py
@@ -86,7 +86,7 @@ def multi_ome_zarr_to_dask(folder: str, remove_unused_dims: bool = True):
     folder : str
         Input folder path
     remove_unused_dims : bool, default True
-        Whether to collapse each  unit-length dimensions
+        Whether to collapse each trivial (length-1) dimension, e.g. (1, 1, 1, 2044, 2048) -> (2044, 2048)
     
     Returns
     -------

--- a/looptrace/image_io.py
+++ b/looptrace/image_io.py
@@ -149,6 +149,7 @@ def parse_times_from_text(s: str) -> List[str]:
 
 
 def single_position_to_zarr(
+    *, 
     images: np.ndarray or list, 
     path: Union[str, Path],
     name: str, 
@@ -279,6 +280,7 @@ def write_jvm_compatible_zarr_store(
 
 
 def images_to_ome_zarr(
+    *, 
     images: Union[np.ndarray, list], 
     path: Union[str, Path], 
     name: str, 
@@ -299,10 +301,30 @@ def images_to_ome_zarr(
     if 'p' in axes:
         for i, pos_img in enumerate(images):
             pos_name = get_position_name_short(i)
-            single_position_to_zarr(pos_img, path, name, pos_name, dtype, axes[1:], chunk_axes, chunk_split, metadata)
+            single_position_to_zarr(
+                images=pos_img, 
+                path=path, 
+                name=name, 
+                pos_name=pos_name, 
+                dtype=dtype, 
+                axes=axes[1:], 
+                chunk_axes=chunk_axes, 
+                chunk_split=chunk_split, 
+                metadata=metadata,
+                )
     else:
         # TODO: fix the fact that here pos_name is undefined.
-        single_position_to_zarr(images, path, name, pos_name, dtype, axes, chunk_axes, chunk_split, metadata)
+        single_position_to_zarr(
+            images=images, 
+            path=path, 
+            name=name, 
+            pos_name=pos_name, 
+            dtype=dtype, 
+            axes=axes, 
+            chunk_axes=chunk_axes, 
+            chunk_split=chunk_split, 
+            metadata=metadata,
+            )
 
 
     print('OME ZARR images generated.')

--- a/looptrace/image_io.py
+++ b/looptrace/image_io.py
@@ -190,17 +190,18 @@ def single_position_to_zarr(
     except AttributeError:
         pass
     for ax in default_axes:
+        sz: int
+        ck: int
         if ax in axes:
             # TODO: fix the signature or implementation of this, as well as call sites, since 
-            #       if images argument is a list, it won't have a .shape attribute to access.
-            size[ax] = images.shape[axes.index(ax)]
-            if ax in chunk_axes:
-                chunk_dict[ax] = size[ax]//chunk_split[chunk_axes.index(ax)]
-            else:
-                chunk_dict[ax] = 1
+            #       if images argument is a list, it won't have a .shape attribute to access.\
+            sz = images.shape[axes.index(ax)]
+            ck = sz // chunk_split[chunk_axes.index(ax)] if ax in chunk_axes else 1
         else:
-            size[ax] = 1
-            chunk_dict[ax] = 1
+            sz = 1
+            ck = 1
+        size[ax] = sz
+        chunk_dict[ax] = ck
     
     print(f"Shape metadata: {size}")
     print(f"Shape metadata: {chunk_dict}")

--- a/looptrace/image_io.py
+++ b/looptrace/image_io.py
@@ -283,7 +283,7 @@ def images_to_ome_zarr(
     *, 
     images: Iterable[npt.ArrayLike], 
     path: Union[str, Path], 
-    name: str, 
+    data_name: str, 
     dtype: Type, 
     axes = ("t", "c", "z", "y", "x"), 
     chunk_axes = ("y", "x"), 
@@ -308,7 +308,7 @@ def images_to_ome_zarr(
         single_position_to_zarr(
             images=pos_img, 
             path=path, 
-            name=name, 
+            name=data_name, 
             pos_name=pos_name, 
             dtype=dtype, 
             axes=axes, 

--- a/looptrace/image_io.py
+++ b/looptrace/image_io.py
@@ -9,6 +9,7 @@ EMBL Heidelberg
 import copy
 from enum import Enum
 import itertools
+import logging
 from operator import itemgetter
 import os
 from pathlib import Path
@@ -282,10 +283,9 @@ def write_jvm_compatible_zarr_store(
 
 def images_to_ome_zarr(
     *, 
-    images: Iterable[npt.ArrayLike], 
+    name_image_pairs: Iterable[npt.ArrayLike], 
     path: Union[str, Path], 
     data_name: str, 
-    dtype: Type, 
     axes = ("t", "c", "z", "y", "x"), 
     chunk_axes = ("y", "x"), 
     chunk_split = (2, 2),  
@@ -304,14 +304,16 @@ def images_to_ome_zarr(
     if not os.path.isdir(path):
         os.makedirs(path)
 
-    for i, pos_img in enumerate(images):
-        pos_name = get_position_name_short(i)
+    bit_depth: PixelArrayBitDepth = PixelArrayBitDepth.get_unique_bit_depth((img for _, img in name_image_pairs))
+    logging.info(f"Will save OME ZARR with bit depth: {bit_depth}")
+
+    for pos_name, pos_img in name_image_pairs:
         single_position_to_zarr(
             images=pos_img, 
             path=path, 
             name=data_name, 
             pos_name=pos_name, 
-            dtype=dtype, 
+            dtype=bit_depth.value, 
             axes=axes, 
             chunk_axes=chunk_axes, 
             chunk_split=chunk_split, 

--- a/looptrace/image_processing_functions.py
+++ b/looptrace/image_processing_functions.py
@@ -203,37 +203,6 @@ def nuc_segmentation_watershed(nuc_img, bg_thresh = 800, fg_thresh = 5000):
     return seg
 
 
-def extract_cell_features(nuc_img, int_imgs: list, nuc_bg_int=800, nuc_fg_int=5000, scale=True):
-    from sklearn import preprocessing
-
-    nuc_masks = nuc_segmentation_watershed(nuc_img, bg_thresh = nuc_bg_int, fg_thresh = nuc_fg_int)
-    expanded = expand_labels(nuc_masks, distance=5)
-    props = [regionprops_table(expanded, int_img, properties=('mean_intensity',))['mean_intensity'] for int_img in int_imgs]
-    res = np.vstack(props).T
-    if scale:
-        scaler = preprocessing.StandardScaler()
-        scaler_model = scaler.fit(res)
-        features = scaler_model.transform(res)
-    else:
-        features = res
-        scaler_model = None
-    return features, scaler_model
-
-
-def full_frame_dc_to_single_nuc_dc(old_dc_path, new_dc_position_list, new_dc_path):
-    new_drifts = []
-    drifts = pd.read_csv(old_dc_path)
-    for i, p in enumerate(new_dc_position_list):
-        pos_name = p.split('_')[0]
-        pos_drifts = drifts.query('position == @pos_name')
-        for j, d in pos_drifts.iterrows():
-            new_drifts.append(d.values.tolist()+[p])
-    new_drifts = pd.DataFrame(new_drifts, columns = ['old_index','frame','z_px_coarse','y_px_coarse','x_px_coarse','z_px_fine',
-    'y_px_fine','x_px_fine','orig_position', 'position'])
-    new_drifts['z_px_coarse', 'y_px_coarse', 'x_px_coarse'] = 0
-    new_drifts.to_csv(new_dc_path)
-
-
 def _index_as_roi_id(props_table: pd.DataFrame) -> pd.DataFrame:
     return props_table.rename(columns={'index': 'roi_id'})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "looptrace"
-version = "0.7.0"
+version = "0.8.0"
 description = "Library and programs for tracing chromatin loops from microscopy images"
 authors = [
     "Kai Sandvold Beckwith",


### PR DESCRIPTION
Close #344 

Also includes a handful of changes noted in commits, regarding writing nuclear mask and classification arrays as ZARR